### PR TITLE
[Release] 학사일정 기능 완료

### DIFF
--- a/academic-service/src/main/java/com/green/academic/application/schedule/AdminScheduleController.java
+++ b/academic-service/src/main/java/com/green/academic/application/schedule/AdminScheduleController.java
@@ -1,13 +1,12 @@
 package com.green.academic.application.schedule;
 
 import com.green.academic.application.schedule.model.ScheduleCreateReq;
+import com.green.academic.application.schedule.model.ScheduleUpdateReq;
+import com.green.academic.application.schedule.model.ScheduleUpdateRes;
 import com.green.common.model.ResultResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +20,20 @@ public class AdminScheduleController {
             @RequestBody ScheduleCreateReq req) {
         scheduleService.createSchedule(req);
         return ResponseEntity.ok(new ResultResponse<>("학사일정 등록 완료", null));
+    }
+
+    @PatchMapping("/{scheduleId}")
+    public ResponseEntity<ResultResponse<ScheduleUpdateRes>> updateSchedule(
+            @PathVariable Long scheduleId,
+            @RequestBody ScheduleUpdateReq req) {
+        return ResponseEntity.ok(new ResultResponse<>("학사일정 변경 완료", scheduleService.updateSchedule(scheduleId, req)));
+    }
+
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<ResultResponse<Void>> deleteSchedule(
+            @PathVariable Long scheduleId) {
+        scheduleService.deleteSchedule(scheduleId);
+        return ResponseEntity.ok(new ResultResponse<>("학사일정 삭제 완료", null));
     }
 
 }

--- a/academic-service/src/main/java/com/green/academic/application/schedule/ScheduleActivator.java
+++ b/academic-service/src/main/java/com/green/academic/application/schedule/ScheduleActivator.java
@@ -1,8 +1,13 @@
 package com.green.academic.application.schedule;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.green.academic.entity.Schedule;
+import com.green.common.kafka.KafkaTopic;
+import com.green.common.kafka.ScheduleEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,11 +21,13 @@ import java.util.List;
 public class ScheduleActivator {
 
     private final ScheduleRepository scheduleRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
 
-//    // 매일 자정 실행
+    //    // 매일 자정 실행
 //    @Scheduled(cron = "0 0 0 * * *")
     //테스트용
-    @Scheduled(fixedDelay = 5_000) // 5초마다
+    @Scheduled(fixedDelay = 30_000) // 30초마다
     @Transactional
     public void updateActiveStatus() {
         LocalDateTime now = LocalDateTime.now();
@@ -30,6 +37,24 @@ public class ScheduleActivator {
             boolean shouldBeActive = !now.isBefore(schedule.getStartDate())
                     && !now.isAfter(schedule.getEndDate());
             schedule.updateActive(shouldBeActive);
+
+            ScheduleEvent event = ScheduleEvent.builder()
+                    .scheduleId(schedule.getScheduleId())
+                    .type(schedule.getType())
+                    .year(schedule.getYear())
+                    .semester(schedule.getSemester())
+                    .startDate(schedule.getStartDate())
+                    .endDate(schedule.getEndDate())
+                    .isActive(shouldBeActive)
+                    .build();
+
+            try {
+                String eventJson = objectMapper.writeValueAsString(event);
+                kafkaTemplate.send(KafkaTopic.SCHEDULE,
+                        String.valueOf(schedule.getScheduleId()), eventJson);
+            } catch (JsonProcessingException e) {
+                log.error("Kafka 직렬화 실패: {}", e.getMessage());
+            }
         }
         log.info("학사일정 활성화 상태 업데이트 완료");
     }

--- a/academic-service/src/main/java/com/green/academic/application/schedule/ScheduleService.java
+++ b/academic-service/src/main/java/com/green/academic/application/schedule/ScheduleService.java
@@ -1,9 +1,6 @@
 package com.green.academic.application.schedule;
 
-import com.green.academic.application.schedule.model.ScheduleActiveRes;
-import com.green.academic.application.schedule.model.ScheduleCreateReq;
-import com.green.academic.application.schedule.model.ScheduleListReq;
-import com.green.academic.application.schedule.model.ScheduleListRes;
+import com.green.academic.application.schedule.model.*;
 import com.green.academic.entity.Schedule;
 import com.green.academic.exception.ScheduleErrorCode;
 import com.green.common.auth.MemberContext;
@@ -71,4 +68,33 @@ public class ScheduleService {
         }
         return data;
     }
+
+    @Transactional
+    public ScheduleUpdateRes updateSchedule(Long scheduleId, ScheduleUpdateReq req) {
+        if (req.getStartDate().isAfter(req.getEndDate())) {
+            throw new BusinessException(ScheduleErrorCode.INVALID_DATE_RANGE);
+        }
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new BusinessException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
+        schedule.update(req.getTitle(), req.getSemester(), req.getStartDate(),
+                req.getEndDate(), req.getType());
+        return ScheduleUpdateRes.builder()
+                .scheduleId(schedule.getScheduleId())
+                .semester(schedule.getSemester())
+                .title(schedule.getTitle())
+                .type(schedule.getType())
+                .startDate(schedule.getStartDate())
+                .endDate(schedule.getEndDate())
+                .isActive(schedule.getIsActive())
+                .updatedAt(schedule.getUpdatedAt())
+                .build();
+    }
+
+    @Transactional
+    public void deleteSchedule(Long scheduleId) {
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new BusinessException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
+        scheduleRepository.delete(schedule);
+    }
+
 }

--- a/academic-service/src/main/java/com/green/academic/application/schedule/ScheduleService.java
+++ b/academic-service/src/main/java/com/green/academic/application/schedule/ScheduleService.java
@@ -49,7 +49,7 @@ public class ScheduleService {
                         s.getTitle(),
                         s.getStartDate().toLocalDate(),
                         s.getEndDate().toLocalDate(),
-                        s.getType(),
+                        s.getType().getCode(),
                         s.getIsActive()
                 ))
                 .toList();

--- a/academic-service/src/main/java/com/green/academic/application/schedule/ScheduleService.java
+++ b/academic-service/src/main/java/com/green/academic/application/schedule/ScheduleService.java
@@ -55,15 +55,18 @@ public class ScheduleService {
                 .toList();
     }
 
+    //학사일정에 따른 메뉴 활성화 로직
     @Transactional(readOnly = true)
     public Map<EnumScheduleType, Boolean> getActiveSchedules() {
         List<Schedule> activeSchedules = scheduleRepository.findByIsActiveTrue();
 
         Map<EnumScheduleType, Boolean> data = new LinkedHashMap<>();
         for (EnumScheduleType type : EnumScheduleType.values()) {
+            if (type == EnumScheduleType.ETC) continue; // ETC 제외
             data.put(type, false);
         }
         for (Schedule schedule : activeSchedules) {
+            if (schedule.getType() == EnumScheduleType.ETC) continue; // ETC 제외
             data.put(schedule.getType(), true);
         }
         return data;

--- a/academic-service/src/main/java/com/green/academic/application/schedule/model/ScheduleListRes.java
+++ b/academic-service/src/main/java/com/green/academic/application/schedule/model/ScheduleListRes.java
@@ -1,6 +1,5 @@
 package com.green.academic.application.schedule.model;
 
-import com.green.common.enumcode.EnumScheduleType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,6 +12,6 @@ public class ScheduleListRes {
     private String title;
     private LocalDate startDate;
     private LocalDate endDate;
-    private EnumScheduleType type;
+    private String type;  // EnumScheduleType → String으로 변경
     private Boolean isActive;
 }

--- a/academic-service/src/main/java/com/green/academic/application/schedule/model/ScheduleUpdateReq.java
+++ b/academic-service/src/main/java/com/green/academic/application/schedule/model/ScheduleUpdateReq.java
@@ -1,0 +1,14 @@
+package com.green.academic.application.schedule.model;
+
+import com.green.common.enumcode.EnumScheduleType;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+public class ScheduleUpdateReq {
+    private String title;
+    private Integer semester;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private EnumScheduleType type;
+}

--- a/academic-service/src/main/java/com/green/academic/application/schedule/model/ScheduleUpdateRes.java
+++ b/academic-service/src/main/java/com/green/academic/application/schedule/model/ScheduleUpdateRes.java
@@ -1,0 +1,19 @@
+package com.green.academic.application.schedule.model;
+
+import com.green.common.enumcode.EnumScheduleType;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ScheduleUpdateRes {
+    private Long scheduleId;
+    private Integer semester;
+    private String title;
+    private EnumScheduleType type;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private Boolean isActive;
+    private LocalDateTime updatedAt;
+}

--- a/academic-service/src/main/java/com/green/academic/entity/Schedule.java
+++ b/academic-service/src/main/java/com/green/academic/entity/Schedule.java
@@ -56,4 +56,15 @@ public class Schedule extends CreatedUpdatedAt {
     public void updateActive(boolean isActive) {
         this.isActive = isActive;
     }
+
+    public void update(String title, Integer semester, LocalDateTime startDate,
+                       LocalDateTime endDate, EnumScheduleType type) {
+        this.title = title;
+        this.semester = semester;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.type = type;
+    }
+
+
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -12,6 +12,9 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'org.springframework.boot:spring-boot-starter-kafka'
 
+    //jackson-datatype-jsr310 의존성(Jackson이 직렬화)
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
     // Spring Data Redis 라이브러리
     compileOnly 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.springframework.boot:spring-boot-starter-cache'

--- a/common/src/main/java/com/green/common/enumcode/EnumScheduleType.java
+++ b/common/src/main/java/com/green/common/enumcode/EnumScheduleType.java
@@ -1,4 +1,5 @@
 package com.green.common.enumcode;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import jakarta.persistence.Converter;
 import lombok.Getter;
@@ -23,7 +24,7 @@ public enum EnumScheduleType implements EnumMapperType {
     @JsonCreator
     public static EnumScheduleType from(String value) {
         for (EnumScheduleType type : EnumScheduleType.values()) {
-            if (type.getCode().equalsIgnoreCase(value)) {
+            if (type.getValue().equals(value) || type.getCode().equals(value)) {
                 return type;
             }
         }

--- a/common/src/main/java/com/green/common/exception/SchedulePeriodErrorCode.java
+++ b/common/src/main/java/com/green/common/exception/SchedulePeriodErrorCode.java
@@ -1,0 +1,22 @@
+package com.green.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SchedulePeriodErrorCode implements ErrorCode {
+    NOT_COURSE_REGISTRATION_PERIOD("SC003", "수강신청 기간이 아닙니다.", HttpStatus.FORBIDDEN),
+    NOT_COURSE_MODIFICATION_PERIOD("SC004", "수강정정 기간이 아닙니다.", HttpStatus.FORBIDDEN),
+    NOT_GRADE_INPUT_PERIOD("SC005", "성적입력 기간이 아닙니다.", HttpStatus.FORBIDDEN),
+    NOT_GRADE_VIEW_PERIOD("SC006", "성적조회 기간이 아닙니다.", HttpStatus.FORBIDDEN),
+    NOT_GRADE_APPEAL_PERIOD("SC007", "성적이의신청 기간이 아닙니다.", HttpStatus.FORBIDDEN),
+    NOT_LECTURE_EVALUATION_PERIOD("SC008", "강의평가 기간이 아닙니다.", HttpStatus.FORBIDDEN),
+    NOT_TUITION_PAYMENT_PERIOD("SC009", "등록금납부 기간이 아닙니다.", HttpStatus.FORBIDDEN),
+    NOT_COURSE_OPEN_PERIOD("SC010", "강의개설신청 기간이 아닙니다.", HttpStatus.FORBIDDEN)
+    ;
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/common/src/main/java/com/green/common/kafka/ScheduleEvent.java
+++ b/common/src/main/java/com/green/common/kafka/ScheduleEvent.java
@@ -1,4 +1,35 @@
 package com.green.common.kafka;
 
-public class ScheduleEvent {
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.green.common.enumcode.EnumScheduleType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleEvent implements Serializable {
+    private Long scheduleId;
+    private EnumScheduleType type;
+    private Integer year;
+    private Integer semester;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime startDate;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime endDate;
+
+    private Boolean isActive;
 }

--- a/core-service/src/main/java/com/green/core/entity/cache/ScheduleCache.java
+++ b/core-service/src/main/java/com/green/core/entity/cache/ScheduleCache.java
@@ -14,10 +14,11 @@ import java.time.LocalDateTime;
 @Builder
 public class ScheduleCache {
 
-    @Id @Tsid
+    @Id
     @Column(name = "schedule_id")
     private Long scheduleId;
 
+    @Convert(converter = EnumScheduleType.CodeConverter.class)
     @Column(name = "type", nullable = false, length = 30)
     private EnumScheduleType type;
 

--- a/core-service/src/main/java/com/green/core/kafka/ScheduleConsumer.java
+++ b/core-service/src/main/java/com/green/core/kafka/ScheduleConsumer.java
@@ -1,21 +1,37 @@
 package com.green.core.kafka;
 
 import com.green.common.kafka.KafkaTopic;
-import com.green.common.kafka.ScheduleEvent;
+import com.green.core.entity.cache.ScheduleCache;
+import com.green.core.repository.ScheduleCacheRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import com.green.common.kafka.ScheduleEvent;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ScheduleConsumer {
 
-//    @Transactional
-//    @KafkaListener(topics = KafkaTopic.SCHEDULE, groupId = "core-service-group")
-//    public void consume(ScheduleEvent event) {
-//
-//    }
+    private final ScheduleCacheRepository scheduleCacheRepository;
+
+    @Transactional
+    @KafkaListener(topics = KafkaTopic.SCHEDULE, groupId = "core-service-group")
+    public void consume(ScheduleEvent event) {
+        log.info("Schedule 이벤트 수신: {}", event);
+
+        ScheduleCache cache = ScheduleCache.builder()
+                .scheduleId(event.getScheduleId())
+                .type(event.getType())
+                .year(event.getYear())
+                .semester(event.getSemester())
+                .startDate(event.getStartDate())
+                .endDate(event.getEndDate())
+                .isActive(event.getIsActive())
+                .build();
+
+        scheduleCacheRepository.save(cache);
+    }
 }

--- a/core-service/src/main/java/com/green/core/scheduleValidator/SchedulePeriodValidator.java
+++ b/core-service/src/main/java/com/green/core/scheduleValidator/SchedulePeriodValidator.java
@@ -1,0 +1,87 @@
+package com.green.core.scheduleValidator;
+
+import com.green.common.enumcode.EnumScheduleType;
+import com.green.common.exception.BusinessException;
+import com.green.common.exception.SchedulePeriodErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import com.green.core.repository.ScheduleCacheRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SchedulePeriodValidator {
+
+    private final ScheduleCacheRepository scheduleCacheRepository;
+
+    // 수강신청 기간 체크
+    public void checkCourseRegistration() {
+        boolean isActive = scheduleCacheRepository
+                .findByTypeAndIsActiveTrue(EnumScheduleType.COURSE_REGISTRATION)
+                .isPresent();
+        if (!isActive) throw new BusinessException(SchedulePeriodErrorCode.NOT_COURSE_REGISTRATION_PERIOD);
+    }
+
+    // 수강정정 기간 체크
+    public void checkCourseModification() {
+        boolean isActive = scheduleCacheRepository
+                .findByTypeAndIsActiveTrue(EnumScheduleType.COURSE_MODIFICATION)
+                .isPresent();
+        if (!isActive) throw new BusinessException(SchedulePeriodErrorCode.NOT_COURSE_MODIFICATION_PERIOD);
+    }
+
+    // 성적입력 기간 체크
+    public void checkGradeInput() {
+        boolean isActive = scheduleCacheRepository
+                .findByTypeAndIsActiveTrue(EnumScheduleType.GRADE_INPUT)
+                .isPresent();
+        if (!isActive) throw new BusinessException(SchedulePeriodErrorCode.NOT_GRADE_INPUT_PERIOD);
+    }
+
+    // 성적조회 기간 체크
+    public void checkGradeView() {
+        boolean isActive = scheduleCacheRepository
+                .findByTypeAndIsActiveTrue(EnumScheduleType.GRADE_VIEW)
+                .isPresent();
+        if (!isActive) throw new BusinessException(SchedulePeriodErrorCode.NOT_GRADE_VIEW_PERIOD);
+    }
+
+    // 성적이의신청 기간 체크
+    public void checkGradeAppeal() {
+        boolean isActive = scheduleCacheRepository
+                .findByTypeAndIsActiveTrue(EnumScheduleType.GRADE_APPEAL)
+                .isPresent();
+        if (!isActive) throw new BusinessException(SchedulePeriodErrorCode.NOT_GRADE_APPEAL_PERIOD);
+    }
+
+    // 강의평가 기간 체크
+    public void checkLectureEvaluation() {
+        boolean isActive = scheduleCacheRepository
+                .findByTypeAndIsActiveTrue(EnumScheduleType.LECTURE_EVALUATION)
+                .isPresent();
+        if (!isActive) throw new BusinessException(SchedulePeriodErrorCode.NOT_LECTURE_EVALUATION_PERIOD);
+    }
+
+    // 등록금납부 기간 체크
+    public void checkTuitionPayment() {
+        boolean isActive = scheduleCacheRepository
+                .findByTypeAndIsActiveTrue(EnumScheduleType.TUITION_PAYMENT)
+                .isPresent();
+        if (!isActive) throw new BusinessException(SchedulePeriodErrorCode.NOT_TUITION_PAYMENT_PERIOD);
+    }
+
+    // 강의개설신청 기간 체크
+    public void checkCourseOpen() {
+        boolean isActive = scheduleCacheRepository
+                .findByTypeAndIsActiveTrue(EnumScheduleType.COURSE_OPEN)
+                .isPresent();
+        if (!isActive) throw new BusinessException(SchedulePeriodErrorCode.NOT_COURSE_OPEN_PERIOD);
+    }
+
+    // 기타 기간 체크
+    public void checkEtc() {
+        boolean isActive = scheduleCacheRepository
+                .findByTypeAndIsActiveTrue(EnumScheduleType.ETC)
+                .isPresent();
+        if (!isActive) throw new BusinessException(SchedulePeriodErrorCode.NOT_ETC_PERIOD);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
closes #54
closes #60
closes #6

## 작업 내용
- CAL-01 학사일정 등록
- CAL-02 학사일정 조회
- CAL-03 학사일정 활성화 상태 조회
- CAL-04 학사일정 변경
- CAL-05 학사일정 삭제
- 학사일정 기간 체크 SchedulePeriodValidator 추가
- 프론트 연동 (Schedule.vue, scheduleService.js)