### PR TITLE
fix(schedule): 학사일정 type 직렬화 value로 통일

### DIFF
--- a/academic-service/src/main/java/com/green/academic/application/schedule/ScheduleService.java
+++ b/academic-service/src/main/java/com/green/academic/application/schedule/ScheduleService.java
@@ -49,7 +49,7 @@ public class ScheduleService {
                         s.getTitle(),
                         s.getStartDate().toLocalDate(),
                         s.getEndDate().toLocalDate(),
-                        s.getType().getCode(),
+                        s.getType(),
                         s.getIsActive()
                 ))
                 .toList();

--- a/academic-service/src/main/java/com/green/academic/application/schedule/model/ScheduleListRes.java
+++ b/academic-service/src/main/java/com/green/academic/application/schedule/model/ScheduleListRes.java
@@ -1,5 +1,6 @@
 package com.green.academic.application.schedule.model;
 
+import com.green.common.enumcode.EnumScheduleType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,6 +13,6 @@ public class ScheduleListRes {
     private String title;
     private LocalDate startDate;
     private LocalDate endDate;
-    private String type;  // EnumScheduleType → String으로 변경
+    private EnumScheduleType type;
     private Boolean isActive;
 }


### PR DESCRIPTION
## 작업 내용
### Backend
- CAL-01 학사일정 등록
- CAL-02 학사일정 조회
- CAL-03 학사일정 활성화 상태 조회 (ETC 제외)
- CAL-04 학사일정 변경
- CAL-05 학사일정 삭제
- Kafka 이벤트 발행 및 schedule_cache 동기화
- SchedulePeriodValidator 추가 (팀 공통 기간 체크)
- SchedulePeriodErrorCode common에 추가
- 학사일정 type 직렬화 value로 통일