### PR TITLE
[fix&feat] 회원 내 정보 수정fix&feat] 회원 내 정보 수정 (#91)

### DIFF
--- a/common/src/main/java/com/green/common/kafka/member/StudentEvent.java
+++ b/common/src/main/java/com/green/common/kafka/member/StudentEvent.java
@@ -29,4 +29,5 @@ public class StudentEvent implements Serializable, KafkaEvent {
     private Boolean isMultiChild;
     private Boolean isVeteran;
     private EventType eventType;
+    private String updateType;
 }

--- a/core-service/src/main/java/com/green/core/entity/cache/ProfessorCache.java
+++ b/core-service/src/main/java/com/green/core/entity/cache/ProfessorCache.java
@@ -24,6 +24,6 @@ public class ProfessorCache {
     @Column(name = "status", nullable = false, length = 20)
     private EnumProfessorStatus status;
 
-    @Column(name = "major_id")
+    @Column(name = "major_id", nullable = false)
     private Long majorId;
 }

--- a/core-service/src/main/java/com/green/core/kafka/StudentConsumer.java
+++ b/core-service/src/main/java/com/green/core/kafka/StudentConsumer.java
@@ -18,14 +18,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class StudentConsumer {
     private final StudentCacheRepository studentCacheRepository;
 
+    @Transactional
     @KafkaListener(topics = MemberTopic.STUDENT, groupId = "core-service-group")
     public void consume(StudentEvent event) {
         log.info("StudentEvent consumed: {}", event);
 
         try {
             EventType type = event.getEventType();
-            if (type == EventType.E_CREATED || type == EventType.E_UPDATED ) {
-                // 저장 또는 수정
+            if (type == EventType.E_CREATED ) {
                 StudentCache cache = StudentCache.builder()
                         .memberCode(event.getMemberCode())
                         .name(event.getName())
@@ -41,10 +41,10 @@ public class StudentConsumer {
                         .build();
                 studentCacheRepository.save(cache);
                 log.info("studentCache 정보저장 완료: {}", event.getMemberCode());
-            }else if (type == EventType.E_DELETED) {
-                // 삭제
-                studentCacheRepository.deleteById(event.getMemberCode());
-                log.info("삭제 완료: {}", event.getMemberCode());
+            } else if (type == EventType.E_UPDATED) {
+                if ("EMAIL".equals(event.getUpdateType())) {
+                    studentCacheRepository.updateEmail(event.getMemberCode(), event.getEmail());
+                }
             }
 
         } catch (Exception e) {

--- a/core-service/src/main/java/com/green/core/repository/StudentCacheRepository.java
+++ b/core-service/src/main/java/com/green/core/repository/StudentCacheRepository.java
@@ -2,6 +2,12 @@ package com.green.core.repository;
 
 import com.green.core.entity.cache.StudentCache;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StudentCacheRepository extends JpaRepository<StudentCache, Long> {
+    @Modifying
+    @Query("UPDATE StudentCache s SET s.email = :email WHERE s.memberCode = :memberCode")
+    void updateEmail(@Param("memberCode") Long memberCode, @Param("email") String email);
 }

--- a/member-service/src/main/java/com/green/member/application/member/MemberHistoryRepository.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.green.member.application.member;
+
+import com.green.member.entity.member.MemberHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberHistoryRepository extends JpaRepository<MemberHistory, Long> {
+}

--- a/member-service/src/main/java/com/green/member/application/member/MemberHistoryService.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberHistoryService.java
@@ -1,0 +1,34 @@
+package com.green.member.application.member;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.green.common.enumcode.EnumChangeType;
+import com.green.member.entity.member.MemberHistory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class MemberHistoryService {
+    private final MemberHistoryRepository memberHistoryRepository;
+    private final MemberRepository memberRepository;
+    private final ObjectMapper objectMapper;
+
+    public void save(Long memberCode, Long updatorCode, Map<String, Object> beforeData) {
+        if (beforeData.isEmpty()) return;
+        try {
+            String json = objectMapper.writeValueAsString(beforeData);
+            MemberHistory history = MemberHistory.builder()
+                    .member(memberRepository.getReferenceById(memberCode))
+                    .changeType(EnumChangeType.UPDATE)
+                    .beforeData(json)
+                    .updatorCode(updatorCode)
+                    .build();
+            memberHistoryRepository.save(history);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("히스토리 직렬화 실패", e);
+        }
+    }
+}

--- a/member-service/src/main/java/com/green/member/application/member/MemberService.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberService.java
@@ -3,6 +3,7 @@ package com.green.member.application.member;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.green.common.constants.EventType;
+import com.green.common.enumcode.EnumChangeType;
 import com.green.common.enumcode.EnumMemberRole;
 import com.green.common.enumcode.EnumMajorType;
 import com.green.common.kafka.KafkaEvent;
@@ -24,6 +25,7 @@ import com.green.member.configuration.MyFileUtil;
 import com.green.member.entity.cache.MajorCache;
 import com.green.member.entity.member.Admin;
 import com.green.member.entity.member.Member;
+import com.green.member.entity.member.MemberHistory;
 import com.green.member.entity.professor.Professor;
 import com.green.member.entity.student.Student;
 import com.green.member.entity.student.StudentMajor;
@@ -35,7 +37,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -50,6 +54,8 @@ public class MemberService {
     private final MyFileUtil myFileUtil;
     private final OutboxRepository outboxRepository;
     private final ObjectMapper objectMapper;
+    private final MemberHistoryRepository memberHistoryRepository;
+    private final MemberHistoryService memberHistoryService;
 
     // 내 정보 조회
     public MemberProfileRes getMyProfile(Long memberCode, EnumMemberRole role){
@@ -202,6 +208,13 @@ public class MemberService {
         }
 
         String oldEmail = member.getEmail();
+        String oldTel = member.getTel();
+        String oldEmergencyTel = member.getEmergencyTel();
+        String oldPostcode = member.getPostcode();
+        String oldAddress = member.getAddress();
+        String oldDetailAddress = member.getDetailAddress();
+        String oldPic = member.getPic();
+
         log.info("oldEmail: {}, reqEmail: {}", oldEmail, req.getEmail());
 
         // 공통 필드 업데이트
@@ -239,11 +252,32 @@ public class MemberService {
             }
         }
 
+        // MemberHistory 저장을 위한 변경된 필드만 수집
+        Map<String, Object> before = new LinkedHashMap<>();
+        if (req.getEmail() != null && !req.getEmail().equals(oldEmail)) before.put("email", oldEmail);
+        if (req.getTel() != null && !req.getTel().equals(oldTel)) before.put("tel", oldTel);
+        if (req.getEmergencyTel() != null && !req.getEmergencyTel().equals(oldEmergencyTel)) before.put("emergencyTel", oldEmergencyTel);
+        if (req.getPostcode() != null && !req.getPostcode().equals(oldPostcode)) before.put("postcode", oldPostcode);
+        if (req.getAddress() != null && !req.getAddress().equals(oldAddress)) before.put("address", oldAddress);
+        if (req.getDetailAddress() != null && !req.getDetailAddress().equals(oldDetailAddress)) before.put("detailAddress", oldDetailAddress);
+        if (savedPicFileName != null && !savedPicFileName.equals(oldPic)) before.put("pic", oldPic);
+
         // 교수 연구실 업데이트
         if (role == EnumMemberRole.PROFESSOR) {
             Professor professor = professorRepository.findById(memberCode).orElseThrow();
+            String oldLabBuilding = professor.getLabBuilding() != null ? professor.getLabBuilding().getCode() : null;
+            String oldLabRoom = professor.getLabRoom();
+            String oldLabTel = professor.getLabTel();
+
             professor.updateLab(req.getLabBuilding(), req.getLabRoom(), req.getLabTel());
+
+            if (req.getLabBuilding() != null && !req.getLabBuilding().getCode().equals(oldLabBuilding)) before.put("labBuilding", oldLabBuilding);
+            if (req.getLabRoom() != null && !req.getLabRoom().equals(oldLabRoom)) before.put("labRoom", oldLabRoom);
+            if (req.getLabTel() != null && !req.getLabTel().equals(oldLabTel)) before.put("labTel", oldLabTel);
         }
+
+        memberHistoryService.save(memberCode, memberCode, before);
+
     }
 
 
@@ -260,6 +294,22 @@ public class MemberService {
             outboxRepository.save(outbox);
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Outbox 직렬화 실패", e);
+        }
+    }
+
+    private void saveMemberHistory(Long memberCode, Long updatorCode, Map<String, Object> beforeData) {
+        if (beforeData.isEmpty()) return;
+        try {
+            String json = objectMapper.writeValueAsString(beforeData);
+            MemberHistory history = MemberHistory.builder()
+                    .member(memberRepository.getReferenceById(memberCode))
+                    .changeType(EnumChangeType.UPDATE)
+                    .beforeData(json)
+                    .updatorCode(updatorCode)
+                    .build();
+            memberHistoryRepository.save(history);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("히스토리 직렬화 실패", e);
         }
     }
 }

--- a/member-service/src/main/java/com/green/member/application/member/MemberService.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberService.java
@@ -201,6 +201,8 @@ public class MemberService {
             }
         }
 
+        String oldEmail = member.getEmail();
+
         // 공통 필드 업데이트
         member.updateCommon(
                 req.getTel(),
@@ -212,29 +214,33 @@ public class MemberService {
                 req.getEmail()
         );
 
-        // AuthMemberEvent Outbox 저장
-        AuthMemberEvent authEvent = AuthMemberEvent.builder()
-                .memberCode(memberCode)
-                .email(req.getEmail())
-                .eventType(EventType.E_UPDATED)
-                .build();
-        saveToOutbox(MemberTopic.AUTH_MEMBER, member.getMemberCode(), authEvent);
+        // 이메일 처리
+        if(req.getEmail() != null && !req.getEmail().equals(oldEmail)){
+
+            // AuthMemberEvent Outbox 저장
+            AuthMemberEvent authEvent = AuthMemberEvent.builder()
+                    .memberCode(memberCode)
+                    .email(req.getEmail())
+                    .eventType(EventType.E_UPDATED)
+                    .build();
+            saveToOutbox(MemberTopic.AUTH_MEMBER, member.getMemberCode(), authEvent);
+
+            // StudentEvent Outbox 저장
+            if (role == EnumMemberRole.STUDENT) {
+                StudentEvent studentEvent = StudentEvent.builder()
+                        .memberCode(member.getMemberCode())
+                        .email(req.getEmail())
+                        .eventType(EventType.E_UPDATED)
+                        .build();
+
+                saveToOutbox(MemberTopic.STUDENT, member.getMemberCode(), studentEvent);
+            }
+        }
 
         // 교수 연구실 업데이트
         if (role == EnumMemberRole.PROFESSOR) {
             Professor professor = professorRepository.findById(memberCode).orElseThrow();
             professor.updateLab(req.getLabBuilding(), req.getLabRoom(), req.getLabTel());
-        }
-
-        if (role == EnumMemberRole.STUDENT) {
-            // StudentEvent Outbox 저장
-            StudentEvent studentEvent = StudentEvent.builder()
-                    .memberCode(member.getMemberCode())
-                    .email(req.getEmail())
-                    .eventType(EventType.E_UPDATED)
-                    .build();
-
-            saveToOutbox(MemberTopic.STUDENT, member.getMemberCode(), studentEvent);
         }
     }
 

--- a/member-service/src/main/java/com/green/member/application/member/MemberService.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberService.java
@@ -202,6 +202,7 @@ public class MemberService {
         }
 
         String oldEmail = member.getEmail();
+        log.info("oldEmail: {}, reqEmail: {}", oldEmail, req.getEmail());
 
         // 공통 필드 업데이트
         member.updateCommon(
@@ -231,6 +232,7 @@ public class MemberService {
                         .memberCode(member.getMemberCode())
                         .email(req.getEmail())
                         .eventType(EventType.E_UPDATED)
+                        .updateType("EMAIL")
                         .build();
 
                 saveToOutbox(MemberTopic.STUDENT, member.getMemberCode(), studentEvent);


### PR DESCRIPTION
## 관련 이슈
#91 

## 관련 기능
API-MEMB-02 | FR-MEMB-05&FR-MEMB-26(시스템) | 회원 | 내 개인정보 수정

## 작업 내용
- 로그인 회원 개인 정보 수정
- 로그인 회원 이메일 수정시 auth_member와 student_cache로 데이터 전송
- 정보 수정 시 정보 변경 이력 테이블 저장