### PR TITLE
[feat] 관리자의 계정 정보 변경 (#113)

### DIFF
--- a/auth-service/src/main/java/com/green/auth/application/auth/AuthService.java
+++ b/auth-service/src/main/java/com/green/auth/application/auth/AuthService.java
@@ -119,5 +119,11 @@ public class AuthService {
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.MEMBER_NOT_FOUND));
         authMember.updateEmail(email);
     }
-
+    // 회원 로그인 상태 변경
+    @Transactional
+    public void deactivate(long memberCode){
+        AuthMember authMember = authMemberRepository.findById(memberCode)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.MEMBER_NOT_FOUND));
+        authMember.deactivate();
+    }
 }

--- a/auth-service/src/main/java/com/green/auth/kafka/AuthMemberConsumer.java
+++ b/auth-service/src/main/java/com/green/auth/kafka/AuthMemberConsumer.java
@@ -29,7 +29,11 @@ public class AuthMemberConsumer {
                     .role(EnumMemberRole.from(event.getRole()))
                     .build());
         } else if (type == EventType.E_UPDATED) {
-            authService.updateEmail(event.getMemberCode(), event.getEmail());
+            if ("EMAIL".equals(event.getUpdateType())) {
+                authService.updateEmail(event.getMemberCode(), event.getEmail());
+            } else if ("DEACTIVATE".equals(event.getUpdateType())) {
+                authService.deactivate(event.getMemberCode());
+            }
         }
     }
 }

--- a/common/src/main/java/com/green/common/kafka/auth/AuthMemberEvent.java
+++ b/common/src/main/java/com/green/common/kafka/auth/AuthMemberEvent.java
@@ -19,5 +19,7 @@ public class AuthMemberEvent implements Serializable, KafkaEvent {
     private String email;
     private String password;
     private String role;
+    private Boolean isActive;
     private EventType eventType;
+    private String updateType;
 }

--- a/common/src/main/java/com/green/common/kafka/member/ProfessorEvent.java
+++ b/common/src/main/java/com/green/common/kafka/member/ProfessorEvent.java
@@ -1,6 +1,7 @@
 package com.green.common.kafka.member;
 
 import com.green.common.constants.EventType;
+import com.green.common.kafka.KafkaEvent;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,11 +13,12 @@ import java.io.Serializable;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ProfessorEvent implements Serializable {
+public class ProfessorEvent implements Serializable, KafkaEvent {
     private Long memberCode;
     private String name;
     private Long majorId;
     private String degree;
     private String status;
     private EventType eventType;
+    private String updateType;
 }

--- a/core-service/src/main/java/com/green/core/kafka/ProfessorConsumer.java
+++ b/core-service/src/main/java/com/green/core/kafka/ProfessorConsumer.java
@@ -25,7 +25,7 @@ public class ProfessorConsumer {
         log.info("ProfessorEvent consumed: {}", event.getMemberCode());
         try {
             EventType type = event.getEventType();
-            if (type == EventType.E_CREATED || type == EventType.E_UPDATED) {
+            if (type == EventType.E_CREATED) {
                 ProfessorCache cache = ProfessorCache.builder()
                         .memberCode(event.getMemberCode())
                         .name(event.getName())
@@ -34,10 +34,21 @@ public class ProfessorConsumer {
                         .status(EnumProfessorStatus.from(event.getStatus()))
                         .build();
                 professorCacheRepository.save(cache);
-                log.info("professorCache 저장 완료: {}", event.getMemberCode());
-            } else if (type == EventType.E_DELETED) {
-                professorCacheRepository.deleteById(event.getMemberCode());
-                log.info("삭제 완료: {}", event.getMemberCode());
+
+            } else if (type == EventType.E_UPDATED) {
+                if ("PROFILE".equals(event.getUpdateType())) {
+                    professorCacheRepository.updateDegreeAndMajorAndName(
+                            event.getMemberCode(),
+                            EnumProfessorDegree.from(event.getDegree()),
+                            event.getMajorId(),
+                            event.getName()
+                    );
+                } else if ("STATUS".equals(event.getUpdateType())) {
+                    professorCacheRepository.updateStatus(
+                            event.getMemberCode(),
+                            EnumProfessorStatus.from(event.getStatus())
+                    );
+                }
             }
         } catch (Exception e) {
             log.error("Kafka 메시지 처리 중 오류 발생: ", e);

--- a/core-service/src/main/java/com/green/core/kafka/StudentConsumer.java
+++ b/core-service/src/main/java/com/green/core/kafka/StudentConsumer.java
@@ -40,10 +40,23 @@ public class StudentConsumer {
                         .isVeteran(event.getIsVeteran())
                         .build();
                 studentCacheRepository.save(cache);
-                log.info("studentCache 정보저장 완료: {}", event.getMemberCode());
             } else if (type == EventType.E_UPDATED) {
                 if ("EMAIL".equals(event.getUpdateType())) {
                     studentCacheRepository.updateEmail(event.getMemberCode(), event.getEmail());
+                } else if ("PROFILE".equals(event.getUpdateType())) {
+                    // TODO: PR 머지 후 활성화
+                    // studentCacheRepository.updateProfile(
+                    //         event.getMemberCode(),
+                    //         event.getName(),
+                    //         event.getMajorId(),
+                    //         event.getIsTransfer(),
+                    //         event.getIsMultiChild(),
+                    //         event.getIsVeteran()
+                    // );
+                } else if ("STATUS".equals(event.getUpdateType())) {
+                    // TODO: PR 머지 후 활성화
+                    // studentCacheRepository.updateStatus(event.getMemberCode(),
+                    //         EnumStudentStatus.from(event.getStatus()));
                 }
             }
 

--- a/core-service/src/main/java/com/green/core/repository/ProfessorCacheRepository.java
+++ b/core-service/src/main/java/com/green/core/repository/ProfessorCacheRepository.java
@@ -1,7 +1,19 @@
 package com.green.core.repository;
 
+import com.green.common.enumcode.EnumProfessorDegree;
+import com.green.common.enumcode.EnumProfessorStatus;
 import com.green.core.entity.cache.ProfessorCache;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProfessorCacheRepository  extends JpaRepository<ProfessorCache, Long> {
+    @Modifying
+    @Query("UPDATE ProfessorCache p SET p.degree = :degree, p.majorId = :majorId, p.name = :name WHERE p.memberCode = :memberCode")
+    void updateDegreeAndMajorAndName(@Param("memberCode") Long memberCode,
+                              @Param("degree") EnumProfessorDegree degree,
+                              @Param("majorId") Long majorId,
+                                @Param("name") String name);
+
 }

--- a/core-service/src/main/java/com/green/core/repository/ProfessorCacheRepository.java
+++ b/core-service/src/main/java/com/green/core/repository/ProfessorCacheRepository.java
@@ -16,4 +16,8 @@ public interface ProfessorCacheRepository  extends JpaRepository<ProfessorCache,
                               @Param("majorId") Long majorId,
                                 @Param("name") String name);
 
+    @Modifying
+    @Query("UPDATE ProfessorCache p SET p.status = :status WHERE p.memberCode = :memberCode")
+    void updateStatus(@Param("memberCode") Long memberCode,
+                      @Param("status") EnumProfessorStatus status);
 }

--- a/member-service/src/main/java/com/green/member/application/OutboxService.java
+++ b/member-service/src/main/java/com/green/member/application/OutboxService.java
@@ -1,0 +1,34 @@
+package com.green.member.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.green.common.kafka.KafkaEvent;
+import com.green.common.outbox.Outbox;
+import com.green.common.outbox.OutboxRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxService {
+    private final OutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+
+    public void saveToOutbox(String topic, Long aggregateId, KafkaEvent event) {
+        log.info("saveToOutbox 호출됨 - topic: {}, aggregateId: {}", topic, aggregateId);
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            Outbox outbox = Outbox.builder()
+                    .topic(topic)
+                    .aggregateId(aggregateId)
+                    .eventType(event.getEventType().name())
+                    .payload(payload)
+                    .build();
+            outboxRepository.save(outbox);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Outbox 직렬화 실패", e);
+        }
+    }
+}

--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -13,6 +13,7 @@ import com.green.member.application.member.model.MemberProfileRes;
 import com.green.member.application.member.model.MemberUpdateReq;
 import com.green.member.application.professor.model.ProfessorCreateReq;
 import com.green.member.application.professor.model.StatusUpdateProfessorReq;
+import com.green.member.application.student.model.StatusUpdateStudentReq;
 import com.green.member.application.student.model.StudentCreateReq;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -109,6 +110,15 @@ public class AdminController {
         adminService.updateProfessorStatus(memberCode, loginMember.memberCode(), req);
         return ResultResponse.builder()
                 .message("교수 계정 상태 변경 및 이력 기록")
+                .build();
+    }
+    // 학생 계정 상태 변경
+    @PatchMapping("/students/{memberCode}/status")
+    public ResultResponse<?> updateStatus(@PathVariable Long memberCode, @RequestBody StatusUpdateStudentReq req) {
+        MemberDto loginMember = MemberContext.get();
+        adminService.updateStudentStatus(memberCode, loginMember.memberCode(), req);
+        return ResultResponse.builder()
+                .message("학생 계정 상태 변경 및 이력 기록")
                 .build();
     }
 

--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -6,10 +6,7 @@ import com.green.common.exception.AuthErrorCode;
 import com.green.common.exception.BusinessException;
 import com.green.common.model.MemberDto;
 import com.green.common.model.ResultResponse;
-import com.green.member.application.admin.model.AdminCreateReq;
-import com.green.member.application.admin.model.AdminMemberUpdateReq;
-import com.green.member.application.admin.model.AdminProfessorUpdateReq;
-import com.green.member.application.admin.model.AdminStudentUpdateReq;
+import com.green.member.application.admin.model.*;
 import com.green.member.application.member.MemberService;
 import com.green.member.application.member.model.MemberCreateRes;
 import com.green.member.application.member.model.MemberProfileRes;
@@ -94,4 +91,15 @@ public class AdminController {
                 .message("학생 계정 정보 수정 성공")
                 .build();
     }
+
+    // 관리자 계정 상태 변경
+    @PatchMapping("/admins/{memberCode}/status")
+    public ResultResponse<?> updateStatus(@PathVariable Long memberCode, @RequestBody StatusUpdateAdminReq req) {
+        MemberDto loginMember = MemberContext.get();
+        adminService.updateAdminStatus(memberCode, loginMember.memberCode(), req);
+        return ResultResponse.builder()
+                .message("관리자 계정 상태 변경 및 이력 기록")
+                .build();
+    }
+
 }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -12,6 +12,7 @@ import com.green.member.application.member.model.MemberCreateRes;
 import com.green.member.application.member.model.MemberProfileRes;
 import com.green.member.application.member.model.MemberUpdateReq;
 import com.green.member.application.professor.model.ProfessorCreateReq;
+import com.green.member.application.professor.model.StatusUpdateProfessorReq;
 import com.green.member.application.student.model.StudentCreateReq;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -99,6 +100,15 @@ public class AdminController {
         adminService.updateAdminStatus(memberCode, loginMember.memberCode(), req);
         return ResultResponse.builder()
                 .message("관리자 계정 상태 변경 및 이력 기록")
+                .build();
+    }
+    // 교수 계정 상태 변경
+    @PatchMapping("/professors/{memberCode}/status")
+    public ResultResponse<?> updateStatus(@PathVariable Long memberCode, @RequestBody StatusUpdateProfessorReq req) {
+        MemberDto loginMember = MemberContext.get();
+        adminService.updateProfessorStatus(memberCode, loginMember.memberCode(), req);
+        return ResultResponse.builder()
+                .message("교수 계정 상태 변경 및 이력 기록")
                 .build();
     }
 

--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -65,19 +65,13 @@ public class AdminController {
                 .build();
     }
 
-    // 관리자 계정 변경
-    @PatchMapping("/{memberCode}/profile")
-    public ResultResponse<?> updateProfile(@PathVariable Long memberCode, @RequestPart AdminMemberUpdateReq req) {
+    // 관리자 계정 정보 수정
+    @PatchMapping("/{memberCode}/admin/profile")
+    public ResultResponse<?> updateProfile(@PathVariable Long memberCode, @RequestBody AdminMemberUpdateReq req) {
         MemberDto loginMember = MemberContext.get();
-        EnumMemberRole role = adminService.getRoleFromMemberCode(memberCode);
-
-        switch (role) {
-            case EnumMemberRole.STUDENT -> adminService.updateStudentProfile(memberCode, loginMember.memberCode(), req);
-            case EnumMemberRole.PROFESSOR -> adminService.updateProfessorProfile(memberCode, loginMember.memberCode(), req);
-            default -> adminService.updateProfile(memberCode, loginMember.memberCode(), req);
-
+        adminService.updateAdminProfile(memberCode, loginMember.memberCode(), req);
         return ResultResponse.builder()
-                .message("관리자의 계정 개인정보 수정")
+                .message("관리자 계정 개인 정보 수정 성공")
                 .build();
     }
 }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -1,10 +1,17 @@
 package com.green.member.application.admin;
 
+import com.green.common.auth.MemberContext;
+import com.green.common.enumcode.EnumMemberRole;
+import com.green.common.exception.AuthErrorCode;
+import com.green.common.exception.BusinessException;
+import com.green.common.model.MemberDto;
 import com.green.common.model.ResultResponse;
 import com.green.member.application.admin.model.AdminCreateReq;
+import com.green.member.application.admin.model.AdminMemberUpdateReq;
 import com.green.member.application.member.MemberService;
 import com.green.member.application.member.model.MemberCreateRes;
 import com.green.member.application.member.model.MemberProfileRes;
+import com.green.member.application.member.model.MemberUpdateReq;
 import com.green.member.application.professor.model.ProfessorCreateReq;
 import com.green.member.application.student.model.StudentCreateReq;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +62,22 @@ public class AdminController {
         return ResultResponse.builder()
                 .message("회원 프로파일 조회")
                 .data(res)
+                .build();
+    }
+
+    // 관리자 계정 변경
+    @PatchMapping("/{memberCode}/profile")
+    public ResultResponse<?> updateProfile(@PathVariable Long memberCode, @RequestPart AdminMemberUpdateReq req) {
+        MemberDto loginMember = MemberContext.get();
+        EnumMemberRole role = adminService.getRoleFromMemberCode(memberCode);
+
+        switch (role) {
+            case EnumMemberRole.STUDENT -> adminService.updateStudentProfile(memberCode, loginMember.memberCode(), req);
+            case EnumMemberRole.PROFESSOR -> adminService.updateProfessorProfile(memberCode, loginMember.memberCode(), req);
+            default -> adminService.updateProfile(memberCode, loginMember.memberCode(), req);
+
+        return ResultResponse.builder()
+                .message("관리자의 계정 개인정보 수정")
                 .build();
     }
 }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -9,6 +9,7 @@ import com.green.common.model.ResultResponse;
 import com.green.member.application.admin.model.AdminCreateReq;
 import com.green.member.application.admin.model.AdminMemberUpdateReq;
 import com.green.member.application.admin.model.AdminProfessorUpdateReq;
+import com.green.member.application.admin.model.AdminStudentUpdateReq;
 import com.green.member.application.member.MemberService;
 import com.green.member.application.member.model.MemberCreateRes;
 import com.green.member.application.member.model.MemberProfileRes;
@@ -82,6 +83,15 @@ public class AdminController {
         adminService.updateProfessor(memberCode, loginMember.memberCode(), req);
         return ResultResponse.builder()
                 .message("교수 계정 정보 수정 성공")
+                .build();
+    }
+    // 학생 계정 정보 수정
+    @PatchMapping("/students/{memberCode}")
+    public ResultResponse<?> updateProfile(@PathVariable Long memberCode, @RequestBody AdminStudentUpdateReq req) {
+        MemberDto loginMember = MemberContext.get();
+        adminService.updateStudent(memberCode, loginMember.memberCode(), req);
+        return ResultResponse.builder()
+                .message("학생 계정 정보 수정 성공")
                 .build();
     }
 }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -8,6 +8,7 @@ import com.green.common.model.MemberDto;
 import com.green.common.model.ResultResponse;
 import com.green.member.application.admin.model.AdminCreateReq;
 import com.green.member.application.admin.model.AdminMemberUpdateReq;
+import com.green.member.application.admin.model.AdminProfessorUpdateReq;
 import com.green.member.application.member.MemberService;
 import com.green.member.application.member.model.MemberCreateRes;
 import com.green.member.application.member.model.MemberProfileRes;
@@ -66,12 +67,21 @@ public class AdminController {
     }
 
     // 관리자 계정 정보 수정
-    @PatchMapping("/{memberCode}/admin/profile")
+    @PatchMapping("/admins/{memberCode}")
     public ResultResponse<?> updateProfile(@PathVariable Long memberCode, @RequestBody AdminMemberUpdateReq req) {
         MemberDto loginMember = MemberContext.get();
-        adminService.updateAdminProfile(memberCode, loginMember.memberCode(), req);
+        adminService.updateAdmin(memberCode, loginMember.memberCode(), req);
         return ResultResponse.builder()
-                .message("관리자 계정 개인 정보 수정 성공")
+                .message("관리자 계정 정보 수정 성공")
+                .build();
+    }
+    // 교수 계정 정보 수정
+    @PatchMapping("/professors/{memberCode}")
+    public ResultResponse<?> updateProfile(@PathVariable Long memberCode, @RequestBody AdminProfessorUpdateReq req) {
+        MemberDto loginMember = MemberContext.get();
+        adminService.updateProfessor(memberCode, loginMember.memberCode(), req);
+        return ResultResponse.builder()
+                .message("교수 계정 정보 수정 성공")
                 .build();
     }
 }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminHistoryRepository.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.green.member.application.admin;
+
+import com.green.member.entity.member.AdminHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminHistoryRepository extends JpaRepository<AdminHistory, Long> {
+}

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -13,10 +13,7 @@ import com.green.common.kafka.member.MemberTopic;
 import com.green.common.outbox.Outbox;
 import com.green.common.outbox.OutboxRepository;
 import com.green.member.application.OutboxService;
-import com.green.member.application.admin.model.AdminCreateReq;
-import com.green.member.application.admin.model.AdminMemberUpdateReq;
-import com.green.member.application.admin.model.AdminProfessorUpdateReq;
-import com.green.member.application.admin.model.AdminStudentUpdateReq;
+import com.green.member.application.admin.model.*;
 import com.green.member.application.member.MemberHistoryRepository;
 import com.green.member.application.member.MemberHistoryService;
 import com.green.member.application.member.MemberRepository;
@@ -32,6 +29,7 @@ import com.green.member.application.student.StudentRepository;
 import com.green.member.application.student.model.StudentCreateReq;
 import com.green.member.configuration.MyFileUtil;
 import com.green.member.entity.member.Admin;
+import com.green.member.entity.member.AdminHistory;
 import com.green.member.entity.member.Member;
 import com.green.member.entity.member.MemberHistory;
 import com.green.member.entity.professor.Professor;
@@ -66,6 +64,7 @@ public class AdminService {
     private final MemberService memberService;
     private final OutboxService outboxService;
     private final MemberHistoryService memberHistoryService;
+    private final AdminHistoryRepository adminHistoryRepository;
 
     // 회원 정보 추가. 공통 처리: member 저장 + memberCode 생성
     private Member createMember(MemberCreateReq req, MultipartFile pic, EnumMemberRole role) {
@@ -379,5 +378,57 @@ public class AdminService {
         if (req.getBirth() != null && !req.getBirth().equals(oldBirth)) before.put("birth", oldBirth);
 
         memberHistoryService.save(memberCode, updaterCode, before);
+    }
+
+    public void updateAdminStatus(Long memberCode, Long updaterCode, StatusUpdateAdminReq req){
+        Admin admin = adminRepository.findById(memberCode).orElseThrow();
+        EnumAdminStatus oldStatus = admin.getStatus();
+        EnumAdminStatus newStatus = req.getStatus();
+
+        // 상태 변경
+        admin.updateStatus(req.getStatus());
+
+        // 퇴사의 경우 exitDate 자동 세팅
+        if (newStatus == EnumAdminStatus.RETIREMENT) {
+            Member member = memberRepository.findById(memberCode).orElseThrow();
+            member.setExitDate(LocalDate.now());
+        }
+
+        // changeType 결정
+        String changeType;
+        if (newStatus == EnumAdminStatus.RETIREMENT) {
+            changeType = "퇴사";
+        } else if (oldStatus == EnumAdminStatus.EMPLOYMENT && newStatus == EnumAdminStatus.ABSENCE) {
+            changeType = "휴직";
+        } else if (oldStatus == EnumAdminStatus.ABSENCE && newStatus == EnumAdminStatus.EMPLOYMENT) {
+            changeType = "복직";
+        } else {
+            changeType = "상태변경";
+        }
+
+        // AdminHistory 저장
+        AdminHistory history = AdminHistory.builder()
+                .admin(admin)
+                .changeType(changeType)
+                .oldStatus(oldStatus)
+                .newStatus(newStatus)
+                .startDate(req.getStartDate())
+                .endDate(req.getEndDate())
+                .reason(req.getReason())
+                .updatorCode(updaterCode)
+                .build();
+        adminHistoryRepository.save(history);
+
+        // 퇴사면 isActive = false 처리 (Kafka)
+        if (newStatus == EnumAdminStatus.RETIREMENT) {
+            AuthMemberEvent authEvent = AuthMemberEvent.builder()
+                    .memberCode(memberCode)
+                    .isActive(false)
+                    .eventType(EventType.E_UPDATED)
+                    .updateType("DEACTIVATE")
+                    .build();
+            outboxService.saveToOutbox(MemberTopic.AUTH_MEMBER, memberCode, authEvent);
+        }
+
     }
 }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -261,8 +261,7 @@ public class AdminService {
         // 공통 필드 업데이트
         member.updateCommonByAdmin(
                 req.getName(),
-                req.getBirth(),
-                req.getExitDate()
+                req.getBirth()
         );
 
         // 학생 필드 업데이트
@@ -281,8 +280,7 @@ public class AdminService {
         // 공통 필드 업데이트
         member.updateCommonByAdmin(
                 req.getName(),
-                req.getBirth(),
-                req.getExitDate()
+                req.getBirth()
         );
 
         // 교수 필드 업데이트
@@ -290,7 +288,7 @@ public class AdminService {
     }
 
     // 관리자 계정 개인 정보 수정
-    public void updateProfile(Long memberCode, Long updatorCode, AdminMemberUpdateReq req) {
+    public void updateAdminProfile(Long memberCode, Long updaterCode, AdminMemberUpdateReq req) {
         Member member = memberRepository.findById(memberCode).orElseThrow();
 
         String oldName = member.getName();
@@ -300,16 +298,14 @@ public class AdminService {
         // 공통 필드 업데이트
         member.updateCommonByAdmin(
                 req.getName(),
-                req.getBirth(),
-                req.getExitDate()
+                req.getBirth()
         );
 
         // MemberHistory 저장을 위한 변경된 필드만 수집
         Map<String, Object> before = new LinkedHashMap<>();
         if (req.getName() != null && !req.getName().equals(oldName)) before.put("name", oldName);
         if (req.getBirth() != null && !req.getBirth().equals(oldBirth)) before.put("birth", oldBirth);
-        if (req.getExitDate() != null && !req.getExitDate().equals(oldExitDate)) before.put("exitDate", oldExitDate);
 
-        memberHistoryService.save(memberCode, updatorCode, before);
+        memberHistoryService.save(memberCode, updaterCode, before);
     }
 }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -3,10 +3,7 @@ package com.green.member.application.admin;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.green.common.constants.EventType;
-import com.green.common.enumcode.EnumMajorType;
-import com.green.common.enumcode.EnumMemberRole;
-import com.green.common.enumcode.EnumProfessorStatus;
-import com.green.common.enumcode.EnumStudentStatus;
+import com.green.common.enumcode.*;
 import com.green.common.exception.AuthErrorCode;
 import com.green.common.exception.BusinessException;
 import com.green.common.kafka.auth.AuthMemberEvent;
@@ -17,11 +14,17 @@ import com.green.common.outbox.Outbox;
 import com.green.common.outbox.OutboxRepository;
 import com.green.member.application.OutboxService;
 import com.green.member.application.admin.model.AdminCreateReq;
+import com.green.member.application.admin.model.AdminMemberUpdateReq;
+import com.green.member.application.admin.model.AdminProfessorUpdateReq;
+import com.green.member.application.admin.model.AdminStudentUpdateReq;
+import com.green.member.application.member.MemberHistoryRepository;
+import com.green.member.application.member.MemberHistoryService;
 import com.green.member.application.member.MemberRepository;
 import com.green.member.application.member.MemberService;
 import com.green.member.application.member.model.MemberCreateReq;
 import com.green.member.application.member.model.MemberCreateRes;
 import com.green.member.application.member.model.MemberProfileRes;
+import com.green.member.application.member.model.MemberUpdateReq;
 import com.green.member.application.professor.ProfessorRepository;
 import com.green.member.application.professor.model.ProfessorCreateReq;
 import com.green.member.application.student.StudentMajorRepository;
@@ -30,6 +33,7 @@ import com.green.member.application.student.model.StudentCreateReq;
 import com.green.member.configuration.MyFileUtil;
 import com.green.member.entity.member.Admin;
 import com.green.member.entity.member.Member;
+import com.green.member.entity.member.MemberHistory;
 import com.green.member.entity.professor.Professor;
 import com.green.member.entity.student.Student;
 import com.green.member.entity.student.StudentMajor;
@@ -42,6 +46,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -57,6 +65,7 @@ public class AdminService {
     private final MyFileUtil myFileUtil;
     private final MemberService memberService;
     private final OutboxService outboxService;
+    private final MemberHistoryService memberHistoryService;
 
     // 회원 정보 추가. 공통 처리: member 저장 + memberCode 생성
     private Member createMember(MemberCreateReq req, MultipartFile pic, EnumMemberRole role) {
@@ -234,7 +243,7 @@ public class AdminService {
         return memberService.getMyProfile(memberCode, role);
     }
 
-    private EnumMemberRole getRoleFromMemberCode(Long memberCode) {
+    public EnumMemberRole getRoleFromMemberCode(Long memberCode) {
         String code = String.valueOf(memberCode);
         char roleChar = code.charAt(code.length() - 4);
         return switch (roleChar) {
@@ -243,5 +252,64 @@ public class AdminService {
             case '3' -> EnumMemberRole.ADMIN;
             default -> throw new BusinessException(AuthErrorCode.MEMBER_NOT_FOUND);
         };
+    }
+
+    // 학생 계정 개인 정보 수정
+    public void updateStudentProfile(Long memberCode, Long updatorCode, AdminStudentUpdateReq req) {
+        Member member = memberRepository.findById(memberCode).orElseThrow();
+
+        // 공통 필드 업데이트
+        member.updateCommonByAdmin(
+                req.getName(),
+                req.getBirth(),
+                req.getExitDate()
+        );
+
+        // 학생 필드 업데이트
+        Student student = studentRepository.findById(memberCode).orElseThrow();
+        student.updateByAdmin(
+                req.getIsTransfer(),
+                req.getIsMultiChild(),
+                req.getIsVeteran()
+        );
+    }
+
+    // 교수 계정 개인 정보 수정
+    public void updateProfessorProfile(Long memberCode, Long updatorCode, AdminProfessorUpdateReq req) {
+        Member member = memberRepository.findById(memberCode).orElseThrow();
+
+        // 공통 필드 업데이트
+        member.updateCommonByAdmin(
+                req.getName(),
+                req.getBirth(),
+                req.getExitDate()
+        );
+
+        // 교수 필드 업데이트
+        Professor professor = professorRepository.findById(memberCode).orElseThrow();
+    }
+
+    // 관리자 계정 개인 정보 수정
+    public void updateProfile(Long memberCode, Long updatorCode, AdminMemberUpdateReq req) {
+        Member member = memberRepository.findById(memberCode).orElseThrow();
+
+        String oldName = member.getName();
+        LocalDate oldBirth = member.getBirth();
+        LocalDate oldExitDate = member.getExitDate();
+
+        // 공통 필드 업데이트
+        member.updateCommonByAdmin(
+                req.getName(),
+                req.getBirth(),
+                req.getExitDate()
+        );
+
+        // MemberHistory 저장을 위한 변경된 필드만 수집
+        Map<String, Object> before = new LinkedHashMap<>();
+        if (req.getName() != null && !req.getName().equals(oldName)) before.put("name", oldName);
+        if (req.getBirth() != null && !req.getBirth().equals(oldBirth)) before.put("birth", oldBirth);
+        if (req.getExitDate() != null && !req.getExitDate().equals(oldExitDate)) before.put("exitDate", oldExitDate);
+
+        memberHistoryService.save(memberCode, updatorCode, before);
     }
 }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -1,6 +1,5 @@
 package com.green.member.application.admin;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.green.common.constants.EventType;
 import com.green.common.enumcode.*;
@@ -10,20 +9,19 @@ import com.green.common.kafka.auth.AuthMemberEvent;
 import com.green.common.kafka.member.ProfessorEvent;
 import com.green.common.kafka.member.StudentEvent;
 import com.green.common.kafka.member.MemberTopic;
-import com.green.common.outbox.Outbox;
 import com.green.common.outbox.OutboxRepository;
 import com.green.member.application.OutboxService;
 import com.green.member.application.admin.model.*;
-import com.green.member.application.member.MemberHistoryRepository;
 import com.green.member.application.member.MemberHistoryService;
 import com.green.member.application.member.MemberRepository;
 import com.green.member.application.member.MemberService;
 import com.green.member.application.member.model.MemberCreateReq;
 import com.green.member.application.member.model.MemberCreateRes;
 import com.green.member.application.member.model.MemberProfileRes;
-import com.green.member.application.member.model.MemberUpdateReq;
+import com.green.member.application.professor.ProfessorHistoryRepository;
 import com.green.member.application.professor.ProfessorRepository;
 import com.green.member.application.professor.model.ProfessorCreateReq;
+import com.green.member.application.professor.model.StatusUpdateProfessorReq;
 import com.green.member.application.student.StudentMajorRepository;
 import com.green.member.application.student.StudentRepository;
 import com.green.member.application.student.model.StudentCreateReq;
@@ -31,8 +29,8 @@ import com.green.member.configuration.MyFileUtil;
 import com.green.member.entity.member.Admin;
 import com.green.member.entity.member.AdminHistory;
 import com.green.member.entity.member.Member;
-import com.green.member.entity.member.MemberHistory;
 import com.green.member.entity.professor.Professor;
+import com.green.member.entity.professor.ProfessorHistory;
 import com.green.member.entity.student.Student;
 import com.green.member.entity.student.StudentMajor;
 import com.green.member.enumcode.EnumAdminStatus;
@@ -45,7 +43,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -58,13 +55,12 @@ public class AdminService {
     private final StudentMajorRepository studentMajorRepository;
     private final ProfessorRepository professorRepository;
     private final AdminRepository adminRepository;
-    private final OutboxRepository outboxRepository;
-    private final ObjectMapper objectMapper;
     private final MyFileUtil myFileUtil;
     private final MemberService memberService;
     private final OutboxService outboxService;
     private final MemberHistoryService memberHistoryService;
     private final AdminHistoryRepository adminHistoryRepository;
+    private final ProfessorHistoryRepository professorHistoryRepository;
 
     // 회원 정보 추가. 공통 처리: member 저장 + memberCode 생성
     private Member createMember(MemberCreateReq req, MultipartFile pic, EnumMemberRole role) {
@@ -388,16 +384,13 @@ public class AdminService {
         // 상태 변경
         admin.updateStatus(req.getStatus());
 
-        // 퇴사의 경우 exitDate 자동 세팅
-        if (newStatus == EnumAdminStatus.RETIREMENT) {
-            Member member = memberRepository.findById(memberCode).orElseThrow();
-            member.setExitDate(LocalDate.now());
-        }
-
         // changeType 결정
         String changeType;
         if (newStatus == EnumAdminStatus.RETIREMENT) {
             changeType = "퇴사";
+            // 퇴사의 경우 exitDate 자동 세팅
+            Member member = memberRepository.findById(memberCode).orElseThrow();
+            member.setExitDate(LocalDate.now());
         } else if (oldStatus == EnumAdminStatus.EMPLOYMENT && newStatus == EnumAdminStatus.ABSENCE) {
             changeType = "휴직";
         } else if (oldStatus == EnumAdminStatus.ABSENCE && newStatus == EnumAdminStatus.EMPLOYMENT) {
@@ -429,6 +422,50 @@ public class AdminService {
                     .build();
             outboxService.saveToOutbox(MemberTopic.AUTH_MEMBER, memberCode, authEvent);
         }
+    }
 
+    public void updateProfessorStatus(Long memberCode, Long updaterCode, StatusUpdateProfessorReq req){
+        Professor professor = professorRepository.findById(memberCode).orElseThrow();
+        EnumProfessorStatus oldStatus = professor.getStatus();
+        EnumProfessorStatus newStatus = req.getStatus();
+        EnumProfessorPosition oldPosition = professor.getPosition();
+        EnumProfessorPosition newPosition = req.getPosition();
+
+        // 상태 변경
+        professor.updateStatusAndPosition(req.getStatus(), req.getPosition());
+
+        // changeType 결정
+        String changeType;
+        if (newStatus == EnumProfessorStatus.RETIREMENT) {
+            changeType = "퇴임";
+            // exitDate 자동 세팅
+            Member member = memberRepository.findById(memberCode).orElseThrow();
+            member.setExitDate(LocalDate.now());
+        } else if (oldStatus == EnumProfessorStatus.EMPLOYMENT && newStatus == EnumProfessorStatus.ABSENCE) {
+            changeType = "휴직";
+        } else if (oldStatus == EnumProfessorStatus.ABSENCE && newStatus == EnumProfessorStatus.EMPLOYMENT) {
+            changeType = "복직";
+        } else if (newStatus == EnumProfessorStatus.SABBATICAL) {
+            changeType = "안식년";
+        } else if (oldStatus == EnumProfessorStatus.SABBATICAL && newStatus == EnumProfessorStatus.EMPLOYMENT) {
+            changeType = "안식년종료";
+        } else {
+            changeType = "상태변경";
+        }
+
+        // ProfessorHistory 저장
+        ProfessorHistory history = ProfessorHistory.builder()
+                .professor(professor)
+                .changeType(changeType)
+                .oldStatus(oldStatus)
+                .newStatus(newStatus)
+                .oldPosition(oldPosition)
+                .newPosition(newPosition)
+                .startDate(req.getStartDate())
+                .endDate(req.getEndDate())
+                .reason(req.getReason())
+                .updatorCode(updaterCode)
+                .build();
+        professorHistoryRepository.save(history);
     }
 }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -273,27 +273,52 @@ public class AdminService {
         );
     }
 
-    // 교수 계정 개인 정보 수정
-    public void updateProfessorProfile(Long memberCode, Long updatorCode, AdminProfessorUpdateReq req) {
-        Member member = memberRepository.findById(memberCode).orElseThrow();
+    // 교수 계정 정보 수정
+    public void updateProfessor(Long memberCode, Long updaterCode, AdminProfessorUpdateReq req) {
 
         // 공통 필드 업데이트
-        member.updateCommonByAdmin(
-                req.getName(),
-                req.getBirth()
-        );
+        Member member = memberRepository.findById(memberCode).orElseThrow();
+        String oldName = member.getName();
+        LocalDate oldBirth = member.getBirth();
+        member.updateCommonByAdmin( req.getName(),req.getBirth() );
 
         // 교수 필드 업데이트
         Professor professor = professorRepository.findById(memberCode).orElseThrow();
+        EnumProfessorDegree oldDegree = professor.getDegree();
+        Long oldMajorId = professor.getMajorId();
+        professor.updateByAdmin( req.getDegree(), req.getMajorId() );
+
+        // MemberHistory 저장
+        Map<String, Object> before = new LinkedHashMap<>();
+        if (req.getName() != null && !req.getName().equals(oldName)) before.put("name", oldName);
+        if (req.getBirth() != null && !req.getBirth().equals(oldBirth)) before.put("birth", oldBirth);
+        if (req.getDegree() != null && !req.getDegree().equals(oldDegree)) before.put("degree", oldDegree);
+        if (req.getMajorId() != null && !req.getMajorId().equals(oldMajorId)) before.put("majorId", oldMajorId);
+        memberHistoryService.save(memberCode, updaterCode, before);
+
+        // ProfessorEvent Outbox 저장
+        boolean nameChanged = req.getName() != null && !req.getName().equals(oldName);
+        boolean degreeChanged = req.getDegree() != null && !req.getDegree().equals(oldDegree);
+        boolean majorChanged = req.getMajorId() != null && !req.getMajorId().equals(oldMajorId);
+        if (nameChanged || degreeChanged || majorChanged) {
+            ProfessorEvent professorEvent = ProfessorEvent.builder()
+                    .memberCode(member.getMemberCode())
+                    .name(member.getName())
+                    .degree(professor.getDegree().getCode())
+                    .majorId(professor.getMajorId())
+                    .eventType(EventType.E_UPDATED)
+                    .updateType("PROFILE")
+                    .build();
+            outboxService.saveToOutbox(MemberTopic.PROFESSOR, member.getMemberCode(), professorEvent);
+        }
     }
 
-    // 관리자 계정 개인 정보 수정
-    public void updateAdminProfile(Long memberCode, Long updaterCode, AdminMemberUpdateReq req) {
+    // 관리자 계정 정보 수정
+    public void updateAdmin(Long memberCode, Long updaterCode, AdminMemberUpdateReq req) {
         Member member = memberRepository.findById(memberCode).orElseThrow();
 
         String oldName = member.getName();
         LocalDate oldBirth = member.getBirth();
-        LocalDate oldExitDate = member.getExitDate();
 
         // 공통 필드 업데이트
         member.updateCommonByAdmin(

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -1,6 +1,5 @@
 package com.green.member.application.admin;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.green.common.constants.EventType;
 import com.green.common.enumcode.*;
 import com.green.common.exception.AuthErrorCode;
@@ -9,7 +8,6 @@ import com.green.common.kafka.auth.AuthMemberEvent;
 import com.green.common.kafka.member.ProfessorEvent;
 import com.green.common.kafka.member.StudentEvent;
 import com.green.common.kafka.member.MemberTopic;
-import com.green.common.outbox.OutboxRepository;
 import com.green.member.application.OutboxService;
 import com.green.member.application.admin.model.*;
 import com.green.member.application.member.MemberHistoryService;
@@ -22,8 +20,10 @@ import com.green.member.application.professor.ProfessorHistoryRepository;
 import com.green.member.application.professor.ProfessorRepository;
 import com.green.member.application.professor.model.ProfessorCreateReq;
 import com.green.member.application.professor.model.StatusUpdateProfessorReq;
+import com.green.member.application.student.StudentHistoryRepository;
 import com.green.member.application.student.StudentMajorRepository;
 import com.green.member.application.student.StudentRepository;
+import com.green.member.application.student.model.StatusUpdateStudentReq;
 import com.green.member.application.student.model.StudentCreateReq;
 import com.green.member.configuration.MyFileUtil;
 import com.green.member.entity.member.Admin;
@@ -32,6 +32,7 @@ import com.green.member.entity.member.Member;
 import com.green.member.entity.professor.Professor;
 import com.green.member.entity.professor.ProfessorHistory;
 import com.green.member.entity.student.Student;
+import com.green.member.entity.student.StudentHistory;
 import com.green.member.entity.student.StudentMajor;
 import com.green.member.enumcode.EnumAdminStatus;
 import com.green.member.enumcode.EnumProfessorPosition;
@@ -61,6 +62,7 @@ public class AdminService {
     private final MemberHistoryService memberHistoryService;
     private final AdminHistoryRepository adminHistoryRepository;
     private final ProfessorHistoryRepository professorHistoryRepository;
+    private final StudentHistoryRepository studentHistoryRepository;
 
     // 회원 정보 추가. 공통 처리: member 저장 + memberCode 생성
     private Member createMember(MemberCreateReq req, MultipartFile pic, EnumMemberRole role) {
@@ -467,5 +469,60 @@ public class AdminService {
                 .updatorCode(updaterCode)
                 .build();
         professorHistoryRepository.save(history);
+    }
+
+    public void updateStudentStatus(Long memberCode, Long updaterCode, StatusUpdateStudentReq req){
+        Student student = studentRepository.findById(memberCode).orElseThrow();
+        EnumStudentStatus oldStatus = student.getStatus();
+        EnumStudentStatus newStatus = req.getStatus();
+
+        // 상태 변경
+        student.updateStatus(req.getStatus());
+
+        // 퇴학, 자최, 졸업의 경우 exitDate 자동 세팅
+        if(newStatus == EnumStudentStatus.EXPULSION || newStatus == EnumStudentStatus.QUIT || newStatus == EnumStudentStatus.GRADUATION){
+            Member member = memberRepository.findById(memberCode).orElseThrow();
+            member.setExitDate(LocalDate.now());
+        }
+
+        // changeType 결정
+        String changeType;
+        if (newStatus == EnumStudentStatus.EXPULSION) {
+            changeType = "퇴학";
+        } else if (newStatus == EnumStudentStatus.ABSENCE) {
+            changeType = "휴학";
+        } else if (oldStatus == EnumStudentStatus.ABSENCE && newStatus == EnumStudentStatus.ENROLLED) {
+            changeType = "복학";
+        } else if (newStatus == EnumStudentStatus.QUIT) {
+            changeType = "자퇴";
+        } else if (newStatus == EnumStudentStatus.GRADUATION) {
+            changeType = "졸업";
+        } else {
+            changeType = "상태변경";
+        }
+
+        // StudentHistory 저장
+        StudentHistory history = StudentHistory.builder()
+                .student(student)
+                .changeType(changeType)
+                .oldStatus(oldStatus)
+                .newStatus(newStatus)
+                .startDate(req.getStartDate())
+                .endDate(req.getEndDate())
+                .reason(req.getReason())
+                .updatorCode(updaterCode)
+                .build();
+        studentHistoryRepository.save(history);
+
+        // 퇴학이면 로그인 불가 처리
+        if (newStatus == EnumStudentStatus.EXPULSION) {
+            AuthMemberEvent authEvent = AuthMemberEvent.builder()
+                    .memberCode(memberCode)
+                    .isActive(false)
+                    .eventType(EventType.E_UPDATED)
+                    .updateType("DEACTIVATE")
+                    .build();
+            outboxService.saveToOutbox(MemberTopic.AUTH_MEMBER, memberCode, authEvent);
+        }
     }
 }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -255,22 +255,69 @@ public class AdminService {
     }
 
     // 학생 계정 개인 정보 수정
-    public void updateStudentProfile(Long memberCode, Long updatorCode, AdminStudentUpdateReq req) {
-        Member member = memberRepository.findById(memberCode).orElseThrow();
+    public void updateStudent(Long memberCode, Long updaterCode, AdminStudentUpdateReq req) {
 
         // 공통 필드 업데이트
-        member.updateCommonByAdmin(
-                req.getName(),
-                req.getBirth()
-        );
+        Member member = memberRepository.findById(memberCode).orElseThrow();
+        String oldName = member.getName();
+        LocalDate oldBirth = member.getBirth();
+        member.updateCommonByAdmin( req.getName(),req.getBirth() );
 
         // 학생 필드 업데이트
         Student student = studentRepository.findById(memberCode).orElseThrow();
+        Boolean oldIsTransfer = student.getIsTransfer();
+        Boolean oldIsMultiChild = student.getIsMultiChild();
+        Boolean oldIsVeteran = student.getIsVeteran();
         student.updateByAdmin(
                 req.getIsTransfer(),
                 req.getIsMultiChild(),
                 req.getIsVeteran()
         );
+
+        // MemberHistory 저장
+        Map<String, Object> before = new LinkedHashMap<>();
+        if (req.getName() != null && !req.getName().equals(oldName)) before.put("name", oldName);
+        if (req.getBirth() != null && !req.getBirth().equals(oldBirth)) before.put("birth", oldBirth);
+        if (req.getIsTransfer() != null && !req.getIsTransfer().equals(oldIsTransfer)) before.put("isTransfer", oldIsTransfer);
+        if (req.getIsMultiChild() != null && !req.getIsMultiChild().equals(oldIsMultiChild)) before.put("isMultiChild", oldIsMultiChild);
+        if (req.getIsVeteran() != null && !req.getIsVeteran().equals(oldIsVeteran)) before.put("isVeteran", oldIsVeteran);
+
+        // 전공 변경 처리
+        StudentMajor currentPrimaryMajor = studentMajorRepository
+                .findByStudent_MemberCodeAndTypeAndIsActiveTrue(memberCode, EnumMajorType.PRIMARY)
+                .orElseThrow();
+        Long currentMajorId = currentPrimaryMajor.getMajorId();
+        if (req.getMajorId() != null && !req.getMajorId().equals(currentMajorId)) {
+            currentPrimaryMajor.deactivate();
+            StudentMajor newPrimaryMajor = StudentMajor.builder()
+                    .student(student)
+                    .majorId(req.getMajorId())
+                    .type(EnumMajorType.PRIMARY)
+                    .build();
+            studentMajorRepository.save(newPrimaryMajor);
+            before.put("majorId", currentMajorId);
+            currentMajorId = req.getMajorId();
+        }
+        memberHistoryService.save(memberCode, updaterCode, before);
+
+        // StudentEvent Outbox 저장
+        boolean nameChanged = req.getName() != null && !req.getName().equals(oldName);
+        boolean transferChanged = req.getIsTransfer() != null && !req.getIsTransfer().equals(oldIsTransfer);
+        boolean multiChildChanged = req.getIsMultiChild() != null && !req.getIsMultiChild().equals(oldIsMultiChild);
+        boolean veteranChanged = req.getIsVeteran() != null && !req.getIsVeteran().equals(oldIsVeteran);
+        if (nameChanged || transferChanged || multiChildChanged || veteranChanged) {
+            StudentEvent studentEvent = StudentEvent.builder()
+                    .memberCode(member.getMemberCode())
+                    .name(member.getName())
+                    .majorId(currentMajorId)  // 새 majorId
+                    .isTransfer(student.getIsTransfer())
+                    .isMultiChild(student.getIsMultiChild())
+                    .isVeteran(student.getIsVeteran())
+                    .eventType(EventType.E_UPDATED)
+                    .updateType("PROFILE")
+                    .build();
+            outboxService.saveToOutbox(MemberTopic.STUDENT, member.getMemberCode(), studentEvent);
+        }
     }
 
     // 교수 계정 정보 수정

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -15,6 +15,7 @@ import com.green.common.kafka.member.StudentEvent;
 import com.green.common.kafka.member.MemberTopic;
 import com.green.common.outbox.Outbox;
 import com.green.common.outbox.OutboxRepository;
+import com.green.member.application.OutboxService;
 import com.green.member.application.admin.model.AdminCreateReq;
 import com.green.member.application.member.MemberRepository;
 import com.green.member.application.member.MemberService;
@@ -55,6 +56,7 @@ public class AdminService {
     private final ObjectMapper objectMapper;
     private final MyFileUtil myFileUtil;
     private final MemberService memberService;
+    private final OutboxService outboxService;
 
     // 회원 정보 추가. 공통 처리: member 저장 + memberCode 생성
     private Member createMember(MemberCreateReq req, MultipartFile pic, EnumMemberRole role) {
@@ -122,8 +124,7 @@ public class AdminService {
                 .role(role.getCode())
                 .eventType(EventType.E_CREATED)
                 .build();
-
-        saveToOutbox(MemberTopic.AUTH_MEMBER, member.getMemberCode(), authEvent);
+        outboxService.saveToOutbox(MemberTopic.AUTH_MEMBER, member.getMemberCode(), authEvent);
 
         return newMember;
     }
@@ -169,7 +170,7 @@ public class AdminService {
                 .isVeteran(savedStudent.getIsVeteran())
                 .eventType(EventType.E_CREATED)
                 .build();
-        saveToOutbox(MemberTopic.STUDENT, member.getMemberCode(), studentEvent);
+        outboxService.saveToOutbox(MemberTopic.STUDENT, member.getMemberCode(), studentEvent);
 
         return MemberCreateRes.builder()
                 .memberCode(member.getMemberCode())
@@ -204,7 +205,7 @@ public class AdminService {
                 .eventType(EventType.E_CREATED)
                 .build();
 
-        saveToOutbox(MemberTopic.PROFESSOR, member.getMemberCode(), professorEvent);
+        outboxService.saveToOutbox(MemberTopic.PROFESSOR, member.getMemberCode(), professorEvent);
 
         return MemberCreateRes.builder()
                 .memberCode(member.getMemberCode())
@@ -226,21 +227,6 @@ public class AdminService {
         return MemberCreateRes.builder()
                 .memberCode(member.getMemberCode())
                 .build();
-    }
-
-    private void saveToOutbox(String topic, Long aggregateId, Object event) {
-        try {
-            String payload = objectMapper.writeValueAsString(event);
-            Outbox outbox = Outbox.builder()
-                    .topic(topic)
-                    .aggregateId(aggregateId)
-                    .eventType(EventType.E_CREATED.name())
-                    .payload(payload)
-                    .build();
-            outboxRepository.save(outbox);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Outbox 직렬화 실패", e);
-        }
     }
 
     public MemberProfileRes getMemberProfile(Long memberCode) {

--- a/member-service/src/main/java/com/green/member/application/admin/model/AdminMemberUpdateReq.java
+++ b/member-service/src/main/java/com/green/member/application/admin/model/AdminMemberUpdateReq.java
@@ -10,5 +10,4 @@ import java.time.LocalDate;
 public class AdminMemberUpdateReq {
     private String name;
     private LocalDate birth;
-    private LocalDate exitDate;
 }

--- a/member-service/src/main/java/com/green/member/application/admin/model/AdminMemberUpdateReq.java
+++ b/member-service/src/main/java/com/green/member/application/admin/model/AdminMemberUpdateReq.java
@@ -1,0 +1,14 @@
+package com.green.member.application.admin.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+public class AdminMemberUpdateReq {
+    private String name;
+    private LocalDate birth;
+    private LocalDate exitDate;
+}

--- a/member-service/src/main/java/com/green/member/application/admin/model/AdminProfessorUpdateReq.java
+++ b/member-service/src/main/java/com/green/member/application/admin/model/AdminProfessorUpdateReq.java
@@ -1,0 +1,14 @@
+package com.green.member.application.admin.model;
+
+import com.green.common.enumcode.EnumProfessorDegree;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+public class AdminProfessorUpdateReq extends AdminMemberUpdateReq{
+    private EnumProfessorDegree degree;
+    private Long majorId;
+}

--- a/member-service/src/main/java/com/green/member/application/admin/model/AdminStudentUpdateReq.java
+++ b/member-service/src/main/java/com/green/member/application/admin/model/AdminStudentUpdateReq.java
@@ -1,0 +1,13 @@
+package com.green.member.application.admin.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class AdminStudentUpdateReq extends AdminMemberUpdateReq{
+    private Long majorId;
+    private Boolean isTransfer;
+    private Boolean isMultiChild;
+    private Boolean isVeteran;
+}

--- a/member-service/src/main/java/com/green/member/application/admin/model/StatusUpdateAdminReq.java
+++ b/member-service/src/main/java/com/green/member/application/admin/model/StatusUpdateAdminReq.java
@@ -1,0 +1,16 @@
+package com.green.member.application.admin.model;
+
+import com.green.member.enumcode.EnumAdminStatus;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+public class StatusUpdateAdminReq {
+    private EnumAdminStatus status;
+    private String reason;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/member-service/src/main/java/com/green/member/application/member/MemberService.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberService.java
@@ -230,6 +230,7 @@ public class MemberService {
                     .memberCode(memberCode)
                     .email(req.getEmail())
                     .eventType(EventType.E_UPDATED)
+                    .updateType("EMAIL")
                     .build();
             outboxService.saveToOutbox(MemberTopic.AUTH_MEMBER, member.getMemberCode(), authEvent);
 

--- a/member-service/src/main/java/com/green/member/application/member/MemberService.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberService.java
@@ -1,17 +1,14 @@
 package com.green.member.application.member;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.green.common.constants.EventType;
-import com.green.common.enumcode.EnumChangeType;
 import com.green.common.enumcode.EnumMemberRole;
 import com.green.common.enumcode.EnumMajorType;
-import com.green.common.kafka.KafkaEvent;
 import com.green.common.kafka.auth.AuthMemberEvent;
 import com.green.common.kafka.member.StudentEvent;
 import com.green.common.kafka.member.MemberTopic;
-import com.green.common.outbox.Outbox;
 import com.green.common.outbox.OutboxRepository;
+import com.green.member.application.OutboxService;
 import com.green.member.application.admin.AdminRepository;
 import com.green.member.application.admin.model.AdminProfileRes;
 import com.green.member.application.member.model.MemberProfileRes;
@@ -25,7 +22,6 @@ import com.green.member.configuration.MyFileUtil;
 import com.green.member.entity.cache.MajorCache;
 import com.green.member.entity.member.Admin;
 import com.green.member.entity.member.Member;
-import com.green.member.entity.member.MemberHistory;
 import com.green.member.entity.professor.Professor;
 import com.green.member.entity.student.Student;
 import com.green.member.entity.student.StudentMajor;
@@ -52,10 +48,8 @@ public class MemberService {
     private final ProfessorRepository professorRepository;
     private final AdminRepository adminRepository;
     private final MyFileUtil myFileUtil;
-    private final OutboxRepository outboxRepository;
-    private final ObjectMapper objectMapper;
-    private final MemberHistoryRepository memberHistoryRepository;
     private final MemberHistoryService memberHistoryService;
+    private final OutboxService outboxService;
 
     // 내 정보 조회
     public MemberProfileRes getMyProfile(Long memberCode, EnumMemberRole role){
@@ -237,7 +231,7 @@ public class MemberService {
                     .email(req.getEmail())
                     .eventType(EventType.E_UPDATED)
                     .build();
-            saveToOutbox(MemberTopic.AUTH_MEMBER, member.getMemberCode(), authEvent);
+            outboxService.saveToOutbox(MemberTopic.AUTH_MEMBER, member.getMemberCode(), authEvent);
 
             // StudentEvent Outbox 저장
             if (role == EnumMemberRole.STUDENT) {
@@ -247,8 +241,7 @@ public class MemberService {
                         .eventType(EventType.E_UPDATED)
                         .updateType("EMAIL")
                         .build();
-
-                saveToOutbox(MemberTopic.STUDENT, member.getMemberCode(), studentEvent);
+                outboxService.saveToOutbox(MemberTopic.STUDENT, member.getMemberCode(), studentEvent);
             }
         }
 
@@ -275,41 +268,8 @@ public class MemberService {
             if (req.getLabRoom() != null && !req.getLabRoom().equals(oldLabRoom)) before.put("labRoom", oldLabRoom);
             if (req.getLabTel() != null && !req.getLabTel().equals(oldLabTel)) before.put("labTel", oldLabTel);
         }
-
         memberHistoryService.save(memberCode, memberCode, before);
 
     }
 
-
-    private void saveToOutbox(String topic, Long aggregateId, KafkaEvent event) {
-        log.info("saveToOutbox 호출됨 - topic: {}, aggregateId: {}", topic, aggregateId);
-        try {
-            String payload = objectMapper.writeValueAsString(event);
-            Outbox outbox = Outbox.builder()
-                    .topic(topic)
-                    .aggregateId(aggregateId)
-                    .eventType(event.getEventType().name())
-                    .payload(payload)
-                    .build();
-            outboxRepository.save(outbox);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Outbox 직렬화 실패", e);
-        }
-    }
-
-    private void saveMemberHistory(Long memberCode, Long updatorCode, Map<String, Object> beforeData) {
-        if (beforeData.isEmpty()) return;
-        try {
-            String json = objectMapper.writeValueAsString(beforeData);
-            MemberHistory history = MemberHistory.builder()
-                    .member(memberRepository.getReferenceById(memberCode))
-                    .changeType(EnumChangeType.UPDATE)
-                    .beforeData(json)
-                    .updatorCode(updatorCode)
-                    .build();
-            memberHistoryRepository.save(history);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("히스토리 직렬화 실패", e);
-        }
-    }
 }

--- a/member-service/src/main/java/com/green/member/application/professor/ProfessorHistoryRepository.java
+++ b/member-service/src/main/java/com/green/member/application/professor/ProfessorHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.green.member.application.professor;
+
+import com.green.member.entity.professor.ProfessorHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProfessorHistoryRepository extends JpaRepository<ProfessorHistory, Long> {
+}

--- a/member-service/src/main/java/com/green/member/application/professor/model/StatusUpdateProfessorReq.java
+++ b/member-service/src/main/java/com/green/member/application/professor/model/StatusUpdateProfessorReq.java
@@ -1,0 +1,19 @@
+package com.green.member.application.professor.model;
+
+import com.green.common.enumcode.EnumProfessorStatus;
+import com.green.member.enumcode.EnumAdminStatus;
+import com.green.member.enumcode.EnumProfessorPosition;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+public class StatusUpdateProfessorReq {
+    private EnumProfessorStatus status;
+    private EnumProfessorPosition position;
+    private String reason;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/member-service/src/main/java/com/green/member/application/student/StudentHistoryRepository.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.green.member.application.student;
+
+import com.green.member.entity.student.StudentHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudentHistoryRepository extends JpaRepository<StudentHistory, Long> {
+}

--- a/member-service/src/main/java/com/green/member/application/student/StudentMajorRepository.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentMajorRepository.java
@@ -1,10 +1,13 @@
 package com.green.member.application.student;
 
+import com.green.common.enumcode.EnumMajorType;
 import com.green.member.entity.student.StudentMajor;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StudentMajorRepository extends JpaRepository<StudentMajor, Long> {
     List<StudentMajor> findByStudent_MemberCodeAndIsActiveTrue(Long memberCode);
+    Optional<StudentMajor> findByStudent_MemberCodeAndTypeAndIsActiveTrue(Long memberCode, EnumMajorType type);
 }

--- a/member-service/src/main/java/com/green/member/application/student/model/StatusUpdateStudentReq.java
+++ b/member-service/src/main/java/com/green/member/application/student/model/StatusUpdateStudentReq.java
@@ -1,0 +1,18 @@
+package com.green.member.application.student.model;
+
+import com.green.common.enumcode.EnumProfessorStatus;
+import com.green.common.enumcode.EnumStudentStatus;
+import com.green.member.enumcode.EnumProfessorPosition;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+public class StatusUpdateStudentReq {
+    private EnumStudentStatus status;
+    private String reason;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/member-service/src/main/java/com/green/member/entity/member/Admin.java
+++ b/member-service/src/main/java/com/green/member/entity/member/Admin.java
@@ -26,4 +26,7 @@ public class Admin extends UpdatedAt {
     @Builder.Default
     private EnumAdminStatus status = EnumAdminStatus.EMPLOYMENT;
 
+    public void updateStatus(EnumAdminStatus status){
+        if (status != null) this.status = status;
+    }
 }

--- a/member-service/src/main/java/com/green/member/entity/member/Member.java
+++ b/member-service/src/main/java/com/green/member/entity/member/Member.java
@@ -71,6 +71,10 @@ public class Member extends CreatedUpdatedAt {
         if(name != null) this.name = name;
         if(birth != null) this.birth = birth;
     }
+
+    public void setExitDate(LocalDate now){
+        this.exitDate = now;
+    }
 }
 
 

--- a/member-service/src/main/java/com/green/member/entity/member/Member.java
+++ b/member-service/src/main/java/com/green/member/entity/member/Member.java
@@ -67,10 +67,9 @@ public class Member extends CreatedUpdatedAt {
         if (email != null) this.email = email;
     }
 
-    public void updateCommonByAdmin(String name, LocalDate birth, LocalDate exitDate){
+    public void updateCommonByAdmin(String name, LocalDate birth){
         if(name != null) this.name = name;
         if(birth != null) this.birth = birth;
-        if(exitDate != null) this.exitDate = exitDate;
     }
 }
 

--- a/member-service/src/main/java/com/green/member/entity/member/Member.java
+++ b/member-service/src/main/java/com/green/member/entity/member/Member.java
@@ -66,6 +66,12 @@ public class Member extends CreatedUpdatedAt {
         if (pic != null) this.pic = pic;
         if (email != null) this.email = email;
     }
+
+    public void updateCommonByAdmin(String name, LocalDate birth, LocalDate exitDate){
+        if(name != null) this.name = name;
+        if(birth != null) this.birth = birth;
+        if(exitDate != null) this.exitDate = exitDate;
+    }
 }
 
 

--- a/member-service/src/main/java/com/green/member/entity/professor/Professor.java
+++ b/member-service/src/main/java/com/green/member/entity/professor/Professor.java
@@ -54,4 +54,9 @@ public class Professor extends UpdatedAt {
         if (labRoom != null) this.labRoom = labRoom;
         if (labTel != null) this.labTel = labTel;
     }
+
+    public void updateByAdmin(EnumProfessorDegree degree, Long majorId){
+        if(degree != null) this.degree = degree;
+        if(majorId != null) this.majorId = majorId;
+    }
 }

--- a/member-service/src/main/java/com/green/member/entity/professor/Professor.java
+++ b/member-service/src/main/java/com/green/member/entity/professor/Professor.java
@@ -59,4 +59,9 @@ public class Professor extends UpdatedAt {
         if(degree != null) this.degree = degree;
         if(majorId != null) this.majorId = majorId;
     }
+
+    public void updateStatusAndPosition(EnumProfessorStatus status, EnumProfessorPosition position){
+        if(status != null) this.status = status;
+        if(position != null) this.position = position;
+    }
 }

--- a/member-service/src/main/java/com/green/member/entity/professor/ProfessorHistory.java
+++ b/member-service/src/main/java/com/green/member/entity/professor/ProfessorHistory.java
@@ -35,10 +35,10 @@ public class ProfessorHistory extends CreatedAt {
     private EnumProfessorStatus newStatus;
 
     // 전임교수, 시간강사, 조교수, 명예교수
-    @Column(name = "old_position", nullable = false, length = 20)
+    @Column(name = "old_position", length = 20)
     private EnumProfessorPosition oldPosition;
 
-    @Column(name = "new_position", nullable = false, length = 20)
+    @Column(name = "new_position", length = 20)
     private EnumProfessorPosition newPosition;
 
     @Column(name = "start_date")

--- a/member-service/src/main/java/com/green/member/entity/student/Student.java
+++ b/member-service/src/main/java/com/green/member/entity/student/Student.java
@@ -5,6 +5,9 @@ import com.green.common.enumcode.EnumStudentStatus;
 import com.green.member.entity.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.time.LocalDate;
+
 @Entity
 @Table(name = "student")
 @Getter
@@ -43,4 +46,10 @@ public class Student extends UpdatedAt {
     @Column(name = "is_veteran", nullable = false)
     @Builder.Default
     private Boolean isVeteran = false;
+
+    public void updateByAdmin(Boolean isTransfer, Boolean isMultiChild, Boolean isVeteran){
+        if(isTransfer != null) this.isTransfer = isTransfer;
+        if(isMultiChild != null) this.isMultiChild = isMultiChild;
+        if(isVeteran != null) this.isVeteran = isVeteran;
+    }
 }

--- a/member-service/src/main/java/com/green/member/entity/student/Student.java
+++ b/member-service/src/main/java/com/green/member/entity/student/Student.java
@@ -6,8 +6,6 @@ import com.green.member.entity.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDate;
-
 @Entity
 @Table(name = "student")
 @Getter
@@ -51,5 +49,9 @@ public class Student extends UpdatedAt {
         if(isTransfer != null) this.isTransfer = isTransfer;
         if(isMultiChild != null) this.isMultiChild = isMultiChild;
         if(isVeteran != null) this.isVeteran = isVeteran;
+    }
+
+    public void updateStatus(EnumStudentStatus status){
+        if(status != null) this.status = status;
     }
 }

--- a/member-service/src/main/java/com/green/member/entity/student/StudentMajor.java
+++ b/member-service/src/main/java/com/green/member/entity/student/StudentMajor.java
@@ -31,4 +31,8 @@ public class StudentMajor extends CreatedUpdatedAt {
     @Column(name = "is_active", nullable = false)
     @Builder.Default
     private Boolean isActive = true;
+
+    public void deactivate() {
+        this.isActive = false;
+    }
 }


### PR DESCRIPTION
## 관련 이슈
#113 

## 관련 기능
FR-MEMB-15FR-MEMB-26(시스템) | 회원 | 관리자의 관리자 회원 정보 수정
회원 | 관리자의 교수 회원 정보 수정
회원 | 관리자 학생 추가정보 수정
FR-MEMB-16FR-MEMB-27(시스템)FR-AUTH-09 | 회원 | 관리자 학생 학적 상태 변경
회원 | 관리자 교수 직무정보 변경
회원 | 관리자 관리자 상태 변경
FR-MEMB-26 | 시스템 | 회원 | 개인정보 변경 이력 기록
FR-MEMB-27 | 시스템 | 회원 | 상태 변경 이력 기록

## 작업 내용
- 관리자 권한의 학생, 교수, 관리자 계정의 개인 정보 변경
- 정보 변경에 따른 변경 이력 관리 테이블 자동 저장
- 정보 변경에 따른 인증 서버, 코어 서버로 데이터 전달 (카프카)
- 관리자 권한의 학생, 교수, 관리자 계정의 상태 정보 변경
- 상태값 변경에 따른 상태 변경 이력 관리 테이블 자동 저장