### PR TITLE
[feat] 상태 변경 이력 조회 기능 구현 (#126)

### DIFF
--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -1,16 +1,11 @@
 package com.green.member.application.admin;
 
 import com.green.common.auth.MemberContext;
-import com.green.common.enumcode.EnumMemberRole;
-import com.green.common.exception.AuthErrorCode;
-import com.green.common.exception.BusinessException;
 import com.green.common.model.MemberDto;
 import com.green.common.model.ResultResponse;
 import com.green.member.application.admin.model.*;
-import com.green.member.application.member.MemberService;
 import com.green.member.application.member.model.MemberCreateRes;
 import com.green.member.application.member.model.MemberProfileRes;
-import com.green.member.application.member.model.MemberUpdateReq;
 import com.green.member.application.professor.model.ProfessorCreateReq;
 import com.green.member.application.professor.model.StatusUpdateProfessorReq;
 import com.green.member.application.student.model.StatusUpdateStudentReq;
@@ -20,12 +15,24 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin")
 public class AdminController {
     private final AdminService adminService;
+
+    @GetMapping("/history")
+    public ResultResponse<?> findHistory(){
+        MemberDto loginMember = MemberContext.get();
+        List<AdminHistoryRes> res = adminService.findStatusHistory( loginMember.memberCode() );
+        return ResultResponse.builder()
+                .message("관리자 상태 변경 이력 조회")
+                .data(res)
+                .build();
+    }
 
     @PostMapping("/students")
     public ResultResponse<?> createStudent(@RequestPart StudentCreateReq req,

--- a/member-service/src/main/java/com/green/member/application/admin/AdminHistoryRepository.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminHistoryRepository.java
@@ -3,5 +3,8 @@ package com.green.member.application.admin;
 import com.green.member.entity.member.AdminHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AdminHistoryRepository extends JpaRepository<AdminHistory, Long> {
+    List<AdminHistory> findByAdmin_MemberCode(Long memberCode);
 }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -45,6 +45,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -558,5 +559,24 @@ public class AdminService {
                     .build();
             outboxService.saveToOutbox(MemberTopic.AUTH_MEMBER, memberCode, authEvent);
         }
+    }
+
+    // 관리자 상태 변경 이력 조회
+    public List<AdminHistoryRes> findStatusHistory(Long memberCode){
+        return adminHistoryRepository.findByAdmin_MemberCode(memberCode)
+                .stream()
+                .map( h -> {
+                    AdminHistoryRes res = new AdminHistoryRes();
+                    res.setChangeType(h.getChangeType());
+                    res.setOldStatus(h.getOldStatus());
+                    res.setNewStatus(h.getNewStatus());
+                    res.setStartDate(h.getStartDate());
+                    res.setEndDate(h.getEndDate());
+                    res.setReason(h.getReason());
+                    res.setCreatedAt(h.getCreatedAt());
+                    return res;
+                })
+                .toList()
+                ;
     }
 }

--- a/member-service/src/main/java/com/green/member/application/admin/model/AdminHistoryRes.java
+++ b/member-service/src/main/java/com/green/member/application/admin/model/AdminHistoryRes.java
@@ -1,0 +1,20 @@
+package com.green.member.application.admin.model;
+
+import com.green.member.enumcode.EnumAdminStatus;
+import lombok.Data;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@ToString
+public class AdminHistoryRes {
+    private String changeType;
+    private EnumAdminStatus oldStatus;
+    private EnumAdminStatus newStatus;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String reason;
+    private LocalDateTime createdAt;
+}

--- a/member-service/src/main/java/com/green/member/application/member/MemberService.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberService.java
@@ -2,7 +2,6 @@ package com.green.member.application.member;
 
 import com.green.common.constants.EventType;
 import com.green.common.enumcode.EnumMemberRole;
-import com.green.common.enumcode.EnumMajorType;
 import com.green.common.kafka.auth.AuthMemberEvent;
 import com.green.common.kafka.member.StudentEvent;
 import com.green.common.kafka.member.MemberTopic;
@@ -13,21 +12,11 @@ import com.green.member.application.member.model.MemberProfileRes;
 import com.green.member.application.member.model.MemberUpdateReq;
 import com.green.member.application.professor.ProfessorRepository;
 import com.green.member.application.professor.ProfessorService;
-import com.green.member.application.professor.model.ProfessorProfileRes;
-import com.green.member.application.student.StudentHistoryRepository;
-import com.green.member.application.student.StudentMajorRepository;
-import com.green.member.application.student.StudentRepository;
 import com.green.member.application.student.StudentService;
-import com.green.member.application.student.model.StudentHistoryRes;
-import com.green.member.application.student.model.StudentProfileRes;
 import com.green.member.configuration.MyFileUtil;
-import com.green.member.entity.cache.MajorCache;
 import com.green.member.entity.member.Admin;
 import com.green.member.entity.member.Member;
 import com.green.member.entity.professor.Professor;
-import com.green.member.entity.student.Student;
-import com.green.member.entity.student.StudentMajor;
-import com.green.member.repository.MajorCacheRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,7 +25,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -45,12 +33,12 @@ import java.util.Map;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final ProfessorRepository professorRepository;
-    private final AdminRepository adminRepository;
     private final MyFileUtil myFileUtil;
     private final MemberHistoryService memberHistoryService;
     private final OutboxService outboxService;
     private final StudentService studentService;
     private final ProfessorService professorService;
+    private final AdminRepository adminRepository;
 
     // 내 정보 조회
     public MemberProfileRes getMyProfile(Long memberCode, EnumMemberRole role){
@@ -61,6 +49,7 @@ public class MemberService {
         };
         return memberProfile;
     }
+
     // 관리자 정보 조회
     public AdminProfileRes findAdmin(Long memberCode, EnumMemberRole role){
         log.info("findAdmin 진입, memberCode: {}", memberCode);

--- a/member-service/src/main/java/com/green/member/application/member/MemberService.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberService.java
@@ -12,6 +12,7 @@ import com.green.member.application.admin.model.AdminProfileRes;
 import com.green.member.application.member.model.MemberProfileRes;
 import com.green.member.application.member.model.MemberUpdateReq;
 import com.green.member.application.professor.ProfessorRepository;
+import com.green.member.application.professor.ProfessorService;
 import com.green.member.application.professor.model.ProfessorProfileRes;
 import com.green.member.application.student.StudentHistoryRepository;
 import com.green.member.application.student.StudentMajorRepository;
@@ -43,56 +44,22 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
-    private final MajorCacheRepository majorCacheRepository;
     private final ProfessorRepository professorRepository;
     private final AdminRepository adminRepository;
     private final MyFileUtil myFileUtil;
     private final MemberHistoryService memberHistoryService;
     private final OutboxService outboxService;
     private final StudentService studentService;
+    private final ProfessorService professorService;
 
     // 내 정보 조회
     public MemberProfileRes getMyProfile(Long memberCode, EnumMemberRole role){
         MemberProfileRes memberProfile = switch (role) {
             case STUDENT   -> studentService.findStudent(memberCode, role);
-            case PROFESSOR -> findProfessor(memberCode, role);
+            case PROFESSOR -> professorService.findProfessor(memberCode, role);
             case ADMIN     -> findAdmin(memberCode, role);
         };
         return memberProfile;
-    }
-    // 교수 정보 조회
-    public ProfessorProfileRes findProfessor(Long memberCode, EnumMemberRole role){
-        Member memberInfo = memberRepository.findById(memberCode).orElseThrow();
-        Professor professorInfo = professorRepository.findById(memberCode).orElseThrow();
-        log.info("professorInfo: {}", professorInfo);
-
-        MajorCache majorCache = majorCacheRepository.findById(professorInfo.getMajorId()).orElseThrow();
-
-        return ProfessorProfileRes.builder()
-                .memberCode(memberInfo.getMemberCode())
-                .role(role.getCode())
-                // 기본 정보
-                .name(memberInfo.getName())
-                .email(memberInfo.getEmail())
-                .address(memberInfo.getAddress())
-                .pic(memberInfo.getPic())
-                .birth(memberInfo.getBirth())
-                .tel(memberInfo.getTel())
-                .emergencyTel(memberInfo.getEmergencyTel())
-                .postcode(memberInfo.getPostcode())
-                .detailAddress(memberInfo.getDetailAddress())
-                .entryDate(memberInfo.getEntryDate())
-                .exitDate(memberInfo.getExitDate())
-                // 학사 정보
-                .degree(professorInfo.getDegree().getCode())
-                .position(professorInfo.getPosition().getCode())
-                .majorName(majorCache.getName())
-                .collegeName(majorCache.getCollegeName())
-                .labBuilding(professorInfo.getLabBuilding().getCode())
-                .labRoom(professorInfo.getLabRoom())
-                .labTel(professorInfo.getLabTel())
-                .status(professorInfo.getStatus().getCode())
-                .build();
     }
     // 관리자 정보 조회
     public AdminProfileRes findAdmin(Long memberCode, EnumMemberRole role){

--- a/member-service/src/main/java/com/green/member/application/member/MemberService.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberService.java
@@ -1,13 +1,11 @@
 package com.green.member.application.member;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.green.common.constants.EventType;
 import com.green.common.enumcode.EnumMemberRole;
 import com.green.common.enumcode.EnumMajorType;
 import com.green.common.kafka.auth.AuthMemberEvent;
 import com.green.common.kafka.member.StudentEvent;
 import com.green.common.kafka.member.MemberTopic;
-import com.green.common.outbox.OutboxRepository;
 import com.green.member.application.OutboxService;
 import com.green.member.application.admin.AdminRepository;
 import com.green.member.application.admin.model.AdminProfileRes;
@@ -15,8 +13,11 @@ import com.green.member.application.member.model.MemberProfileRes;
 import com.green.member.application.member.model.MemberUpdateReq;
 import com.green.member.application.professor.ProfessorRepository;
 import com.green.member.application.professor.model.ProfessorProfileRes;
+import com.green.member.application.student.StudentHistoryRepository;
 import com.green.member.application.student.StudentMajorRepository;
 import com.green.member.application.student.StudentRepository;
+import com.green.member.application.student.StudentService;
+import com.green.member.application.student.model.StudentHistoryRes;
 import com.green.member.application.student.model.StudentProfileRes;
 import com.green.member.configuration.MyFileUtil;
 import com.green.member.entity.cache.MajorCache;
@@ -43,73 +44,21 @@ import java.util.Map;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final MajorCacheRepository majorCacheRepository;
-    private final StudentRepository studentRepository;
-    private final StudentMajorRepository studentMajorRepository;
     private final ProfessorRepository professorRepository;
     private final AdminRepository adminRepository;
     private final MyFileUtil myFileUtil;
     private final MemberHistoryService memberHistoryService;
     private final OutboxService outboxService;
+    private final StudentService studentService;
 
     // 내 정보 조회
     public MemberProfileRes getMyProfile(Long memberCode, EnumMemberRole role){
         MemberProfileRes memberProfile = switch (role) {
-            case STUDENT   -> findStudent(memberCode, role);
+            case STUDENT   -> studentService.findStudent(memberCode, role);
             case PROFESSOR -> findProfessor(memberCode, role);
             case ADMIN     -> findAdmin(memberCode, role);
         };
         return memberProfile;
-    }
-    // 학생 정보 조회
-    public StudentProfileRes findStudent(Long memberCode, EnumMemberRole role){
-        Member memberInfo = memberRepository.findById(memberCode).orElseThrow();
-        log.info("memberInfo : {}", memberInfo);
-        Student studentInfo = studentRepository.findById(memberCode).orElseThrow();
-        log.info("studentInfo: {}", studentInfo);
-        List<StudentMajor> majors = studentMajorRepository.findByStudent_MemberCodeAndIsActiveTrue(memberCode);
-        log.info("majors: {}", majors);
-
-        StudentMajor mainMajor = majors.stream()
-                .filter(m -> m.getType() == EnumMajorType.PRIMARY)
-                .findFirst()
-                .orElseThrow();
-        StudentMajor subMajor = majors.stream()
-                .filter(m -> m.getType() == EnumMajorType.MINOR)
-                .findFirst()
-                .orElse(null);
-        MajorCache mainMajorCache = majorCacheRepository.findById(mainMajor.getMajorId()).orElseThrow();
-        String subMajorName = null;
-        if (subMajor != null) {
-            MajorCache subMajorCache = majorCacheRepository.findById(subMajor.getMajorId()).orElseThrow();
-            subMajorName = subMajorCache.getName();
-        }
-
-        return StudentProfileRes.builder()
-                .memberCode(memberInfo.getMemberCode())
-                .role(role.getCode())
-                // 기본 정보
-                .name(memberInfo.getName())
-                .email(memberInfo.getEmail())
-                .address(memberInfo.getAddress())
-                .pic(memberInfo.getPic())
-                .birth(memberInfo.getBirth())
-                .tel(memberInfo.getTel())
-                .emergencyTel(memberInfo.getEmergencyTel())
-                .postcode(memberInfo.getPostcode())
-                .detailAddress(memberInfo.getDetailAddress())
-                .entryDate(memberInfo.getEntryDate())
-                .exitDate(memberInfo.getExitDate())
-                // 학사 정보
-                .academicYear(studentInfo.getAcademicYear())
-                .semester(studentInfo.getSemester())
-                .mainMajorName(mainMajorCache.getName())
-                .subMajorName(subMajorName)
-                .collegeName(mainMajorCache.getCollegeName())
-                .isMultiChild(studentInfo.getIsMultiChild())
-                .isTransfer(studentInfo.getIsTransfer())
-                .isVeteran(studentInfo.getIsVeteran())
-                .status(studentInfo.getStatus().getCode())
-                .build();
     }
     // 교수 정보 조회
     public ProfessorProfileRes findProfessor(Long memberCode, EnumMemberRole role){

--- a/member-service/src/main/java/com/green/member/application/professor/ProfessorController.java
+++ b/member-service/src/main/java/com/green/member/application/professor/ProfessorController.java
@@ -1,4 +1,31 @@
 package com.green.member.application.professor;
 
+import com.green.common.auth.MemberContext;
+import com.green.common.model.MemberDto;
+import com.green.common.model.ResultResponse;
+import com.green.member.application.professor.model.ProfessorHistoryRes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/professor")
 public class ProfessorController {
+    private final ProfessorService professorService;
+
+    @GetMapping("/history")
+    public ResultResponse<?> findHistory(){
+        MemberDto loginMember = MemberContext.get();
+        List<ProfessorHistoryRes> res = professorService.findStatusHistory( loginMember.memberCode() );
+        return ResultResponse.builder()
+                .message("교수 상태 변경 이력 조회")
+                .data(res)
+                .build();
+    }
 }

--- a/member-service/src/main/java/com/green/member/application/professor/ProfessorHistoryRepository.java
+++ b/member-service/src/main/java/com/green/member/application/professor/ProfessorHistoryRepository.java
@@ -3,5 +3,8 @@ package com.green.member.application.professor;
 import com.green.member.entity.professor.ProfessorHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProfessorHistoryRepository extends JpaRepository<ProfessorHistory, Long> {
+    List<ProfessorHistory> findByProfessor_MemberCode(Long memberCode);
 }

--- a/member-service/src/main/java/com/green/member/application/professor/ProfessorService.java
+++ b/member-service/src/main/java/com/green/member/application/professor/ProfessorService.java
@@ -1,0 +1,81 @@
+package com.green.member.application.professor;
+
+import com.green.common.enumcode.EnumMemberRole;
+import com.green.member.application.member.MemberRepository;
+import com.green.member.application.professor.model.ProfessorHistoryRes;
+import com.green.member.application.professor.model.ProfessorProfileRes;
+import com.green.member.entity.cache.MajorCache;
+import com.green.member.entity.member.Member;
+import com.green.member.entity.professor.Professor;
+import com.green.member.repository.MajorCacheRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProfessorService {
+    private final MemberRepository memberRepository;
+    private final MajorCacheRepository majorCacheRepository;
+    private final ProfessorRepository professorRepository;
+    private final ProfessorHistoryRepository professorHistoryRepository;
+
+    // 교수 정보 조회
+    public ProfessorProfileRes findProfessor(Long memberCode, EnumMemberRole role){
+        Member memberInfo = memberRepository.findById(memberCode).orElseThrow();
+        Professor professorInfo = professorRepository.findById(memberCode).orElseThrow();
+        log.info("professorInfo: {}", professorInfo);
+
+        MajorCache majorCache = majorCacheRepository.findById(professorInfo.getMajorId()).orElseThrow();
+
+        return ProfessorProfileRes.builder()
+                .memberCode(memberInfo.getMemberCode())
+                .role(role.getCode())
+                // 기본 정보
+                .name(memberInfo.getName())
+                .email(memberInfo.getEmail())
+                .address(memberInfo.getAddress())
+                .pic(memberInfo.getPic())
+                .birth(memberInfo.getBirth())
+                .tel(memberInfo.getTel())
+                .emergencyTel(memberInfo.getEmergencyTel())
+                .postcode(memberInfo.getPostcode())
+                .detailAddress(memberInfo.getDetailAddress())
+                .entryDate(memberInfo.getEntryDate())
+                .exitDate(memberInfo.getExitDate())
+                // 학사 정보
+                .degree(professorInfo.getDegree().getCode())
+                .position(professorInfo.getPosition().getCode())
+                .majorName(majorCache.getName())
+                .collegeName(majorCache.getCollegeName())
+                .labBuilding(professorInfo.getLabBuilding().getCode())
+                .labRoom(professorInfo.getLabRoom())
+                .labTel(professorInfo.getLabTel())
+                .status(professorInfo.getStatus().getCode())
+                .build();
+    }
+
+    // 교수 상태 변경 이력 조회
+    public List<ProfessorHistoryRes> findStatusHistory(Long memberCode){
+        return professorHistoryRepository.findByProfessor_MemberCode(memberCode)
+                .stream()
+                .map( h -> {
+                    ProfessorHistoryRes res = new ProfessorHistoryRes();
+                    res.setChangeType(h.getChangeType());
+                    res.setOldStatus(h.getOldStatus());
+                    res.setNewStatus(h.getNewStatus());
+                    res.setOldPosition(h.getOldPosition());
+                    res.setNewPosition(h.getNewPosition());
+                    res.setStartDate(h.getStartDate());
+                    res.setEndDate(h.getEndDate());
+                    res.setReason(h.getReason());
+                    res.setCreatedAt(h.getCreatedAt());
+                    return res;
+                })
+                .toList()
+                ;
+    }
+}

--- a/member-service/src/main/java/com/green/member/application/professor/model/ProfessorHistoryRes.java
+++ b/member-service/src/main/java/com/green/member/application/professor/model/ProfessorHistoryRes.java
@@ -1,0 +1,23 @@
+package com.green.member.application.professor.model;
+
+import com.green.common.enumcode.EnumProfessorStatus;
+import com.green.member.enumcode.EnumProfessorPosition;
+import lombok.Data;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@ToString
+public class ProfessorHistoryRes {
+    private String changeType;
+    EnumProfessorStatus oldStatus;
+    EnumProfessorStatus newStatus;
+    EnumProfessorPosition oldPosition;
+    EnumProfessorPosition newPosition;
+    LocalDate startDate;
+    LocalDate endDate;
+    String reason;
+    LocalDateTime createdAt;
+}

--- a/member-service/src/main/java/com/green/member/application/student/StudentController.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentController.java
@@ -3,7 +3,6 @@ package com.green.member.application.student;
 import com.green.common.auth.MemberContext;
 import com.green.common.model.MemberDto;
 import com.green.common.model.ResultResponse;
-import com.green.member.application.member.MemberService;
 import com.green.member.application.student.model.StudentHistoryRes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/member-service/src/main/java/com/green/member/application/student/StudentController.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentController.java
@@ -18,7 +18,6 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/student")
 public class StudentController {
-    private final MemberService memberService;
     private final StudentService studentService;
 
     @GetMapping("/history")
@@ -26,7 +25,7 @@ public class StudentController {
         MemberDto loginMember = MemberContext.get();
         List<StudentHistoryRes> res = studentService.findStudentHistory( loginMember.memberCode() );
         return ResultResponse.builder()
-                .message("회원 프로파일 조회")
+                .message("학생 상태 변경 이력 조회")
                 .data(res)
                 .build();
     }

--- a/member-service/src/main/java/com/green/member/application/student/StudentController.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentController.java
@@ -1,4 +1,33 @@
 package com.green.member.application.student;
 
+import com.green.common.auth.MemberContext;
+import com.green.common.model.MemberDto;
+import com.green.common.model.ResultResponse;
+import com.green.member.application.member.MemberService;
+import com.green.member.application.student.model.StudentHistoryRes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/student")
 public class StudentController {
+    private final MemberService memberService;
+    private final StudentService studentService;
+
+    @GetMapping("/history")
+    public ResultResponse<?> findHistory(){
+        MemberDto loginMember = MemberContext.get();
+        List<StudentHistoryRes> res = studentService.findStudentHistory( loginMember.memberCode() );
+        return ResultResponse.builder()
+                .message("회원 프로파일 조회")
+                .data(res)
+                .build();
+    }
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentHistoryRepository.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentHistoryRepository.java
@@ -3,5 +3,8 @@ package com.green.member.application.student;
 import com.green.member.entity.student.StudentHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StudentHistoryRepository extends JpaRepository<StudentHistory, Long> {
+    List<StudentHistory> findByStudent_MemberCode(Long memberCode);
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -1,0 +1,112 @@
+package com.green.member.application.student;
+
+import com.green.common.enumcode.EnumMajorType;
+import com.green.common.enumcode.EnumMemberRole;
+import com.green.member.application.OutboxService;
+import com.green.member.application.admin.AdminRepository;
+import com.green.member.application.member.MemberHistoryService;
+import com.green.member.application.member.MemberRepository;
+import com.green.member.application.professor.ProfessorRepository;
+import com.green.member.application.student.model.StudentHistoryRes;
+import com.green.member.application.student.model.StudentProfileRes;
+import com.green.member.configuration.MyFileUtil;
+import com.green.member.entity.cache.MajorCache;
+import com.green.member.entity.member.Member;
+import com.green.member.entity.student.Student;
+import com.green.member.entity.student.StudentMajor;
+import com.green.member.repository.MajorCacheRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StudentService {
+    private final MemberRepository memberRepository;
+    private final MajorCacheRepository majorCacheRepository;
+    private final StudentRepository studentRepository;
+    private final StudentMajorRepository studentMajorRepository;
+    private final ProfessorRepository professorRepository;
+    private final AdminRepository adminRepository;
+    private final MyFileUtil myFileUtil;
+    private final MemberHistoryService memberHistoryService;
+    private final OutboxService outboxService;
+    private final StudentHistoryRepository studentHistoryRepository;
+
+
+    // 학생 정보 조회
+    public StudentProfileRes findStudent(Long memberCode, EnumMemberRole role){
+        Member memberInfo = memberRepository.findById(memberCode).orElseThrow();
+        log.info("memberInfo : {}", memberInfo);
+        Student studentInfo = studentRepository.findById(memberCode).orElseThrow();
+        log.info("studentInfo: {}", studentInfo);
+        List<StudentMajor> majors = studentMajorRepository.findByStudent_MemberCodeAndIsActiveTrue(memberCode);
+        log.info("majors: {}", majors);
+
+        StudentMajor mainMajor = majors.stream()
+                .filter(m -> m.getType() == EnumMajorType.PRIMARY)
+                .findFirst()
+                .orElseThrow();
+        StudentMajor subMajor = majors.stream()
+                .filter(m -> m.getType() == EnumMajorType.MINOR)
+                .findFirst()
+                .orElse(null);
+        MajorCache mainMajorCache = majorCacheRepository.findById(mainMajor.getMajorId()).orElseThrow();
+        String subMajorName = null;
+        if (subMajor != null) {
+            MajorCache subMajorCache = majorCacheRepository.findById(subMajor.getMajorId()).orElseThrow();
+            subMajorName = subMajorCache.getName();
+        }
+
+        return StudentProfileRes.builder()
+                .memberCode(memberInfo.getMemberCode())
+                .role(role.getCode())
+                // 기본 정보
+                .name(memberInfo.getName())
+                .email(memberInfo.getEmail())
+                .address(memberInfo.getAddress())
+                .pic(memberInfo.getPic())
+                .birth(memberInfo.getBirth())
+                .tel(memberInfo.getTel())
+                .emergencyTel(memberInfo.getEmergencyTel())
+                .postcode(memberInfo.getPostcode())
+                .detailAddress(memberInfo.getDetailAddress())
+                .entryDate(memberInfo.getEntryDate())
+                .exitDate(memberInfo.getExitDate())
+                // 학사 정보
+                .academicYear(studentInfo.getAcademicYear())
+                .semester(studentInfo.getSemester())
+                .mainMajorName(mainMajorCache.getName())
+                .subMajorName(subMajorName)
+                .collegeName(mainMajorCache.getCollegeName())
+                .isMultiChild(studentInfo.getIsMultiChild())
+                .isTransfer(studentInfo.getIsTransfer())
+                .isVeteran(studentInfo.getIsVeteran())
+                .status(studentInfo.getStatus().getCode())
+                .build();
+    }
+
+    // 학생 상태 변경 이력 조회
+    public List<StudentHistoryRes> findStudentHistory(Long memberCode){
+        return studentHistoryRepository.findByStudent_MemberCode(memberCode)
+                .stream()
+                .map( h -> {
+                    StudentHistoryRes res = new StudentHistoryRes();
+                    res.setChangeType(h.getChangeType());
+                    res.setOldStatus(h.getOldStatus());
+                    res.setNewStatus(h.getNewStatus());
+                    res.setStartDate(h.getStartDate());
+                    res.setEndDate(h.getEndDate());
+                    res.setReason(h.getReason());
+                    res.setReturnYear(h.getReturnYear());
+                    res.setReturnSemester(h.getReturnSemester());
+                    res.setCreatedAt(h.getCreatedAt());
+                    return res;
+                })
+                .toList()
+                ;
+    }
+}

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -2,14 +2,9 @@ package com.green.member.application.student;
 
 import com.green.common.enumcode.EnumMajorType;
 import com.green.common.enumcode.EnumMemberRole;
-import com.green.member.application.OutboxService;
-import com.green.member.application.admin.AdminRepository;
-import com.green.member.application.member.MemberHistoryService;
 import com.green.member.application.member.MemberRepository;
-import com.green.member.application.professor.ProfessorRepository;
 import com.green.member.application.student.model.StudentHistoryRes;
 import com.green.member.application.student.model.StudentProfileRes;
-import com.green.member.configuration.MyFileUtil;
 import com.green.member.entity.cache.MajorCache;
 import com.green.member.entity.member.Member;
 import com.green.member.entity.student.Student;
@@ -29,13 +24,7 @@ public class StudentService {
     private final MajorCacheRepository majorCacheRepository;
     private final StudentRepository studentRepository;
     private final StudentMajorRepository studentMajorRepository;
-    private final ProfessorRepository professorRepository;
-    private final AdminRepository adminRepository;
-    private final MyFileUtil myFileUtil;
-    private final MemberHistoryService memberHistoryService;
-    private final OutboxService outboxService;
     private final StudentHistoryRepository studentHistoryRepository;
-
 
     // 학생 정보 조회
     public StudentProfileRes findStudent(Long memberCode, EnumMemberRole role){

--- a/member-service/src/main/java/com/green/member/application/student/model/StudentHistoryRes.java
+++ b/member-service/src/main/java/com/green/member/application/student/model/StudentHistoryRes.java
@@ -1,0 +1,22 @@
+package com.green.member.application.student.model;
+
+import com.green.common.enumcode.EnumStudentStatus;
+import lombok.Data;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@ToString
+public class StudentHistoryRes {
+    String changeType;
+    EnumStudentStatus oldStatus;
+    EnumStudentStatus newStatus;
+    LocalDate startDate;
+    LocalDate endDate;
+    String reason;
+    Integer returnYear;
+    Integer returnSemester;
+    LocalDateTime createdAt;
+}


### PR DESCRIPTION
## 관련 이슈
#126

## 관련 기능
FR-MEMB-06| 회원 | 학생 학적 변동 변동 이력 조회
FR-MEMB-07| 회원 | 교수 직위/상태 변동 이력 조회
FR-MEMB-07 | 회원 | 관리자 재직 상태 변동 이력 조회

## 작업 내용
- 학생 변동 이력 조회
- 교수 변동 이력 조회
- 관리자 변동 이력 조회
- 공통/학생/교수/관리자 권한별 서비스 클래스 분리