### PR TITLE
[fix] 상태 변경 수동 처리 및 변경 이력 조회 #126

### DIFF
--- a/auth-service/src/main/java/com/green/auth/application/auth/AuthService.java
+++ b/auth-service/src/main/java/com/green/auth/application/auth/AuthService.java
@@ -119,11 +119,12 @@ public class AuthService {
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.MEMBER_NOT_FOUND));
         authMember.updateEmail(email);
     }
-    // 회원 로그인 상태 변경
+    // 회원 로그인 가능 여부 변경
     @Transactional
     public void deactivate(long memberCode){
         AuthMember authMember = authMemberRepository.findById(memberCode)
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.MEMBER_NOT_FOUND));
         authMember.deactivate();
+        redisService.deleteAllByMemberCode(memberCode);
     }
 }

--- a/auth-service/src/main/java/com/green/auth/entity/AuthMember.java
+++ b/auth-service/src/main/java/com/green/auth/entity/AuthMember.java
@@ -35,9 +35,7 @@ public class AuthMember extends CreatedUpdatedAt {
     @Builder.Default
     private Boolean isFirstLogin = true;
 
-    public void deactivate() {
-        this.isActive = false;
-    }
+    public void deactivate() { this.isActive = false; }
     public void updatePassword(String hashedPw) { this.password = hashedPw;  }
     public void updateFirstLogin() { this.isFirstLogin = false; }
     public void updateEmail(String email){ this.email = email; }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminHistoryRepository.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminHistoryRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface AdminHistoryRepository extends JpaRepository<AdminHistory, Long> {
-    List<AdminHistory> findByAdmin_MemberCode(Long memberCode);
+    List<AdminHistory> findByAdmin_MemberCodeOrderByCreatedAtDesc(Long memberCode);
 }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -253,6 +253,7 @@ public class AdminService {
     }
 
     // 학생 계정 개인 정보 수정
+    @Transactional
     public void updateStudent(Long memberCode, Long updaterCode, AdminStudentUpdateReq req) {
 
         // 공통 필드 업데이트
@@ -319,6 +320,7 @@ public class AdminService {
     }
 
     // 교수 계정 정보 수정
+    @Transactional
     public void updateProfessor(Long memberCode, Long updaterCode, AdminProfessorUpdateReq req) {
 
         // 공통 필드 업데이트
@@ -359,6 +361,7 @@ public class AdminService {
     }
 
     // 관리자 계정 정보 수정
+    @Transactional
     public void updateAdmin(Long memberCode, Long updaterCode, AdminMemberUpdateReq req) {
         Member member = memberRepository.findById(memberCode).orElseThrow();
 
@@ -565,6 +568,7 @@ public class AdminService {
     }
 
     // 관리자 상태 변경 이력 조회
+    @Transactional(readOnly = true)
     public List<AdminHistoryRes> findStatusHistory(Long memberCode){
         return adminHistoryRepository.findByAdmin_MemberCode(memberCode)
                 .stream()

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -2,7 +2,7 @@ package com.green.member.application.admin;
 
 import com.green.common.constants.EventType;
 import com.green.common.enumcode.*;
-import com.green.common.exception.AuthErrorCode;
+import com.green.member.exception.MemberErrorCode;
 import com.green.common.exception.BusinessException;
 import com.green.common.kafka.auth.AuthMemberEvent;
 import com.green.common.kafka.member.ProfessorEvent;
@@ -248,7 +248,7 @@ public class AdminService {
             case '1' -> EnumMemberRole.STUDENT;
             case '2' -> EnumMemberRole.PROFESSOR;
             case '3' -> EnumMemberRole.ADMIN;
-            default -> throw new BusinessException(AuthErrorCode.MEMBER_NOT_FOUND);
+            default -> throw new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND);
         };
     }
 
@@ -257,13 +257,13 @@ public class AdminService {
     public void updateStudent(Long memberCode, Long updaterCode, AdminStudentUpdateReq req) {
 
         // 공통 필드 업데이트
-        Member member = memberRepository.findById(memberCode).orElseThrow();
+        Member member = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
         String oldName = member.getName();
         LocalDate oldBirth = member.getBirth();
         member.updateCommonByAdmin( req.getName(),req.getBirth() );
 
         // 학생 필드 업데이트
-        Student student = studentRepository.findById(memberCode).orElseThrow();
+        Student student = studentRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND));
         Boolean oldIsTransfer = student.getIsTransfer();
         Boolean oldIsMultiChild = student.getIsMultiChild();
         Boolean oldIsVeteran = student.getIsVeteran();
@@ -324,13 +324,13 @@ public class AdminService {
     public void updateProfessor(Long memberCode, Long updaterCode, AdminProfessorUpdateReq req) {
 
         // 공통 필드 업데이트
-        Member member = memberRepository.findById(memberCode).orElseThrow();
+        Member member = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
         String oldName = member.getName();
         LocalDate oldBirth = member.getBirth();
         member.updateCommonByAdmin( req.getName(),req.getBirth() );
 
         // 교수 필드 업데이트
-        Professor professor = professorRepository.findById(memberCode).orElseThrow();
+        Professor professor = professorRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.PROFESSOR_NOT_FOUND));
         EnumProfessorDegree oldDegree = professor.getDegree();
         Long oldMajorId = professor.getMajorId();
         professor.updateByAdmin( req.getDegree(), req.getMajorId() );
@@ -363,7 +363,7 @@ public class AdminService {
     // 관리자 계정 정보 수정
     @Transactional
     public void updateAdmin(Long memberCode, Long updaterCode, AdminMemberUpdateReq req) {
-        Member member = memberRepository.findById(memberCode).orElseThrow();
+        Member member = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         String oldName = member.getName();
         LocalDate oldBirth = member.getBirth();
@@ -396,7 +396,7 @@ public class AdminService {
         if (newStatus == EnumAdminStatus.RETIREMENT) {
             changeType = "퇴사";
             // 퇴사의 경우 exitDate 자동 세팅
-            Member member = memberRepository.findById(memberCode).orElseThrow();
+            Member member = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
             member.setExitDate(LocalDate.now());
         } else if (oldStatus == EnumAdminStatus.EMPLOYMENT && newStatus == EnumAdminStatus.ABSENCE) {
             changeType = "휴직";
@@ -447,7 +447,7 @@ public class AdminService {
             if (newStatus == EnumProfessorStatus.RETIREMENT) {
                 changeType = "퇴임";
                 // exitDate 자동 세팅
-                Member member = memberRepository.findById(memberCode).orElseThrow();
+                Member member = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
                 member.setExitDate(LocalDate.now());
             } else if (oldStatus == EnumProfessorStatus.EMPLOYMENT && newStatus == EnumProfessorStatus.ABSENCE) {
                 changeType = "휴직";
@@ -511,9 +511,9 @@ public class AdminService {
         // 상태 변경
         student.updateStatus(req.getStatus());
 
-        // 퇴학, 자최, 졸업의 경우 exitDate 자동 세팅
+        // 퇴학, 자퇴, 졸업의 경우 exitDate 자동 세팅
         if(newStatus == EnumStudentStatus.EXPULSION || newStatus == EnumStudentStatus.QUIT || newStatus == EnumStudentStatus.GRADUATION){
-            Member member = memberRepository.findById(memberCode).orElseThrow();
+            Member member = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
             member.setExitDate(LocalDate.now());
         }
 

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -285,6 +285,7 @@ public class AdminService {
         StudentMajor currentPrimaryMajor = studentMajorRepository
                 .findByStudent_MemberCodeAndTypeAndIsActiveTrue(memberCode, EnumMajorType.PRIMARY)
                 .orElseThrow();
+        boolean majorChanged = false;
         Long currentMajorId = currentPrimaryMajor.getMajorId();
         if (req.getMajorId() != null && !req.getMajorId().equals(currentMajorId)) {
             currentPrimaryMajor.deactivate();
@@ -296,6 +297,7 @@ public class AdminService {
             studentMajorRepository.save(newPrimaryMajor);
             before.put("majorId", currentMajorId);
             currentMajorId = req.getMajorId();
+            majorChanged = true;
         }
         memberHistoryService.save(memberCode, updaterCode, before);
 
@@ -304,11 +306,11 @@ public class AdminService {
         boolean transferChanged = req.getIsTransfer() != null && !req.getIsTransfer().equals(oldIsTransfer);
         boolean multiChildChanged = req.getIsMultiChild() != null && !req.getIsMultiChild().equals(oldIsMultiChild);
         boolean veteranChanged = req.getIsVeteran() != null && !req.getIsVeteran().equals(oldIsVeteran);
-        if (nameChanged || transferChanged || multiChildChanged || veteranChanged) {
+        if (nameChanged || transferChanged || multiChildChanged || veteranChanged || majorChanged) {
             StudentEvent studentEvent = StudentEvent.builder()
                     .memberCode(member.getMemberCode())
                     .name(member.getName())
-                    .majorId(currentMajorId)  // 새 majorId
+                    .majorId(currentMajorId)
                     .isTransfer(student.getIsTransfer())
                     .isMultiChild(student.getIsMultiChild())
                     .isVeteran(student.getIsVeteran())
@@ -384,7 +386,7 @@ public class AdminService {
 
     @Transactional
     public void updateAdminStatus(Long memberCode, Long updaterCode, StatusUpdateAdminReq req){
-        Admin admin = adminRepository.findById(memberCode).orElseThrow();
+        Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
         EnumAdminStatus oldStatus = admin.getStatus();
         EnumAdminStatus newStatus = req.getStatus();
 
@@ -433,7 +435,7 @@ public class AdminService {
 
     @Transactional
     public void updateProfessorStatus(Long memberCode, Long updaterCode, StatusUpdateProfessorReq req){
-        Professor professor = professorRepository.findById(memberCode).orElseThrow();
+        Professor professor = professorRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.PROFESSOR_NOT_FOUND));
         EnumProfessorStatus oldStatus = professor.getStatus();
         EnumProfessorStatus newStatus = req.getStatus();
         EnumProfessorPosition oldPosition = professor.getPosition();
@@ -499,12 +501,23 @@ public class AdminService {
                     .updatorCode(updaterCode)
                     .build();
             professorHistoryRepository.save(history);
+
+            // 퇴임이면 로그인 불가 처리
+            if (newStatus == EnumProfessorStatus.RETIREMENT) {
+                AuthMemberEvent authEvent = AuthMemberEvent.builder()
+                        .memberCode(memberCode)
+                        .isActive(false)
+                        .eventType(EventType.E_UPDATED)
+                        .updateType("DEACTIVATE")
+                        .build();
+                outboxService.saveToOutbox(MemberTopic.AUTH_MEMBER, memberCode, authEvent);
+            }
         }
     }
 
     @Transactional
     public void updateStudentStatus(Long memberCode, Long updaterCode, StatusUpdateStudentReq req){
-        Student student = studentRepository.findById(memberCode).orElseThrow();
+        Student student = studentRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND));
         EnumStudentStatus oldStatus = student.getStatus();
         EnumStudentStatus newStatus = req.getStatus();
 

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -379,6 +379,7 @@ public class AdminService {
         memberHistoryService.save(memberCode, updaterCode, before);
     }
 
+    @Transactional
     public void updateAdminStatus(Long memberCode, Long updaterCode, StatusUpdateAdminReq req){
         Admin admin = adminRepository.findById(memberCode).orElseThrow();
         EnumAdminStatus oldStatus = admin.getStatus();
@@ -427,6 +428,7 @@ public class AdminService {
         }
     }
 
+    @Transactional
     public void updateProfessorStatus(Long memberCode, Long updaterCode, StatusUpdateProfessorReq req){
         Professor professor = professorRepository.findById(memberCode).orElseThrow();
         EnumProfessorStatus oldStatus = professor.getStatus();
@@ -497,6 +499,7 @@ public class AdminService {
         }
     }
 
+    @Transactional
     public void updateStudentStatus(Long memberCode, Long updaterCode, StatusUpdateStudentReq req){
         Student student = studentRepository.findById(memberCode).orElseThrow();
         EnumStudentStatus oldStatus = student.getStatus();
@@ -549,8 +552,8 @@ public class AdminService {
                     .build();
             outboxService.saveToOutbox(MemberTopic.STUDENT, student.getMemberCode(), studentEvent);
 
-        // 퇴학이면 로그인 불가 처리
-        if (newStatus == EnumStudentStatus.EXPULSION) {
+        // 자퇴/퇴학이면 로그인 불가 처리
+        if (newStatus == EnumStudentStatus.EXPULSION || newStatus == EnumStudentStatus.QUIT) {
             AuthMemberEvent authEvent = AuthMemberEvent.builder()
                     .memberCode(memberCode)
                     .isActive(false)

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -570,7 +570,7 @@ public class AdminService {
     // 관리자 상태 변경 이력 조회
     @Transactional(readOnly = true)
     public List<AdminHistoryRes> findStatusHistory(Long memberCode){
-        return adminHistoryRepository.findByAdmin_MemberCode(memberCode)
+        return adminHistoryRepository.findByAdmin_MemberCodeOrderByCreatedAtDesc(memberCode)
                 .stream()
                 .map( h -> {
                     AdminHistoryRes res = new AdminHistoryRes();

--- a/member-service/src/main/java/com/green/member/application/member/MemberService.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberService.java
@@ -55,7 +55,6 @@ public class MemberService {
     }
 
     // 관리자 정보 조회
-    @Transactional(readOnly = true)
     public AdminProfileRes findAdmin(Long memberCode, EnumMemberRole role){
         log.info("findAdmin 진입, memberCode: {}", memberCode);
         Member memberInfo = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/member-service/src/main/java/com/green/member/application/member/MemberService.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberService.java
@@ -41,6 +41,7 @@ public class MemberService {
     private final AdminRepository adminRepository;
 
     // 내 정보 조회
+    @Transactional(readOnly = true)
     public MemberProfileRes getMyProfile(Long memberCode, EnumMemberRole role){
         MemberProfileRes memberProfile = switch (role) {
             case STUDENT   -> studentService.findStudent(memberCode, role);
@@ -51,6 +52,7 @@ public class MemberService {
     }
 
     // 관리자 정보 조회
+    @Transactional(readOnly = true)
     public AdminProfileRes findAdmin(Long memberCode, EnumMemberRole role){
         log.info("findAdmin 진입, memberCode: {}", memberCode);
         Member memberInfo = memberRepository.findById(memberCode).orElseThrow();

--- a/member-service/src/main/java/com/green/member/application/member/MemberService.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberService.java
@@ -2,6 +2,8 @@ package com.green.member.application.member;
 
 import com.green.common.constants.EventType;
 import com.green.common.enumcode.EnumMemberRole;
+import com.green.common.exception.AuthErrorCode;
+import com.green.common.exception.BusinessException;
 import com.green.common.kafka.auth.AuthMemberEvent;
 import com.green.common.kafka.member.StudentEvent;
 import com.green.common.kafka.member.MemberTopic;
@@ -17,6 +19,7 @@ import com.green.member.configuration.MyFileUtil;
 import com.green.member.entity.member.Admin;
 import com.green.member.entity.member.Member;
 import com.green.member.entity.professor.Professor;
+import com.green.member.exception.MemberErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -55,9 +58,9 @@ public class MemberService {
     @Transactional(readOnly = true)
     public AdminProfileRes findAdmin(Long memberCode, EnumMemberRole role){
         log.info("findAdmin 진입, memberCode: {}", memberCode);
-        Member memberInfo = memberRepository.findById(memberCode).orElseThrow();
+        Member memberInfo = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
         log.info("memberInfo: {}", memberInfo);
-        Admin adminInfo = adminRepository.findById(memberCode).orElseThrow();
+        Admin adminInfo = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
         log.info("adminInfo: {}", adminInfo);
 
         return AdminProfileRes.builder()
@@ -84,7 +87,7 @@ public class MemberService {
     @Transactional
     public void updateMyProfile(Long memberCode, EnumMemberRole role,
                                 MemberUpdateReq req, MultipartFile pic) {
-        Member member = memberRepository.findById(memberCode).orElseThrow();
+        Member member = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         // 사진 처리
         String savedPicFileName = null;
@@ -165,7 +168,7 @@ public class MemberService {
 
         // 교수 연구실 업데이트
         if (role == EnumMemberRole.PROFESSOR) {
-            Professor professor = professorRepository.findById(memberCode).orElseThrow();
+            Professor professor = professorRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.PROFESSOR_NOT_FOUND));
             String oldLabBuilding = professor.getLabBuilding() != null ? professor.getLabBuilding().getCode() : null;
             String oldLabRoom = professor.getLabRoom();
             String oldLabTel = professor.getLabTel();

--- a/member-service/src/main/java/com/green/member/application/professor/ProfessorHistoryRepository.java
+++ b/member-service/src/main/java/com/green/member/application/professor/ProfessorHistoryRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ProfessorHistoryRepository extends JpaRepository<ProfessorHistory, Long> {
-    List<ProfessorHistory> findByProfessor_MemberCode(Long memberCode);
+    List<ProfessorHistory> findByProfessor_MemberCodeOrderByCreatedAtDesc(Long memberCode);
 }

--- a/member-service/src/main/java/com/green/member/application/professor/ProfessorService.java
+++ b/member-service/src/main/java/com/green/member/application/professor/ProfessorService.java
@@ -28,7 +28,6 @@ public class ProfessorService {
     private final ProfessorHistoryRepository professorHistoryRepository;
 
     // 교수 정보 조회
-    @Transactional(readOnly = true)
     public ProfessorProfileRes findProfessor(Long memberCode, EnumMemberRole role){
         Member memberInfo = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
         Professor professorInfo = professorRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.PROFESSOR_NOT_FOUND));
@@ -56,7 +55,7 @@ public class ProfessorService {
                 .position(professorInfo.getPosition().getCode())
                 .majorName(majorCache.getName())
                 .collegeName(majorCache.getCollegeName())
-                .labBuilding(professorInfo.getLabBuilding().getCode())
+                .labBuilding(professorInfo.getLabBuilding() != null ? professorInfo.getLabBuilding().getCode() : null)
                 .labRoom(professorInfo.getLabRoom())
                 .labTel(professorInfo.getLabTel())
                 .status(professorInfo.getStatus().getCode())
@@ -66,7 +65,7 @@ public class ProfessorService {
     // 교수 상태 변경 이력 조회
     @Transactional(readOnly = true)
     public List<ProfessorHistoryRes> findStatusHistory(Long memberCode){
-        return professorHistoryRepository.findByProfessor_MemberCode(memberCode)
+        return professorHistoryRepository.findByProfessor_MemberCodeOrderByCreatedAtDesc(memberCode)
                 .stream()
                 .map( h -> {
                     ProfessorHistoryRes res = new ProfessorHistoryRes();

--- a/member-service/src/main/java/com/green/member/application/professor/ProfessorService.java
+++ b/member-service/src/main/java/com/green/member/application/professor/ProfessorService.java
@@ -11,6 +11,7 @@ import com.green.member.repository.MajorCacheRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -24,6 +25,7 @@ public class ProfessorService {
     private final ProfessorHistoryRepository professorHistoryRepository;
 
     // 교수 정보 조회
+    @Transactional(readOnly = true)
     public ProfessorProfileRes findProfessor(Long memberCode, EnumMemberRole role){
         Member memberInfo = memberRepository.findById(memberCode).orElseThrow();
         Professor professorInfo = professorRepository.findById(memberCode).orElseThrow();
@@ -59,6 +61,7 @@ public class ProfessorService {
     }
 
     // 교수 상태 변경 이력 조회
+    @Transactional(readOnly = true)
     public List<ProfessorHistoryRes> findStatusHistory(Long memberCode){
         return professorHistoryRepository.findByProfessor_MemberCode(memberCode)
                 .stream()

--- a/member-service/src/main/java/com/green/member/application/professor/ProfessorService.java
+++ b/member-service/src/main/java/com/green/member/application/professor/ProfessorService.java
@@ -1,12 +1,15 @@
 package com.green.member.application.professor;
 
 import com.green.common.enumcode.EnumMemberRole;
+import com.green.common.exception.AuthErrorCode;
+import com.green.common.exception.BusinessException;
 import com.green.member.application.member.MemberRepository;
 import com.green.member.application.professor.model.ProfessorHistoryRes;
 import com.green.member.application.professor.model.ProfessorProfileRes;
 import com.green.member.entity.cache.MajorCache;
 import com.green.member.entity.member.Member;
 import com.green.member.entity.professor.Professor;
+import com.green.member.exception.MemberErrorCode;
 import com.green.member.repository.MajorCacheRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,11 +30,11 @@ public class ProfessorService {
     // 교수 정보 조회
     @Transactional(readOnly = true)
     public ProfessorProfileRes findProfessor(Long memberCode, EnumMemberRole role){
-        Member memberInfo = memberRepository.findById(memberCode).orElseThrow();
-        Professor professorInfo = professorRepository.findById(memberCode).orElseThrow();
+        Member memberInfo = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Professor professorInfo = professorRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.PROFESSOR_NOT_FOUND));
         log.info("professorInfo: {}", professorInfo);
 
-        MajorCache majorCache = majorCacheRepository.findById(professorInfo.getMajorId()).orElseThrow();
+        MajorCache majorCache = majorCacheRepository.findById(professorInfo.getMajorId()).orElseThrow(() -> new BusinessException(MemberErrorCode.MAJOR_NOT_FOUND));
 
         return ProfessorProfileRes.builder()
                 .memberCode(memberInfo.getMemberCode())

--- a/member-service/src/main/java/com/green/member/application/student/StudentHistoryRepository.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentHistoryRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface StudentHistoryRepository extends JpaRepository<StudentHistory, Long> {
-    List<StudentHistory> findByStudent_MemberCode(Long memberCode);
+    List<StudentHistory> findByStudent_MemberCodeOrderByCreatedAtDesc(Long memberCode);
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -13,6 +13,7 @@ import com.green.member.repository.MajorCacheRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -27,6 +28,7 @@ public class StudentService {
     private final StudentHistoryRepository studentHistoryRepository;
 
     // 학생 정보 조회
+    @Transactional(readOnly = true)
     public StudentProfileRes findStudent(Long memberCode, EnumMemberRole role){
         Member memberInfo = memberRepository.findById(memberCode).orElseThrow();
         log.info("memberInfo : {}", memberInfo);
@@ -79,6 +81,7 @@ public class StudentService {
     }
 
     // 학생 상태 변경 이력 조회
+    @Transactional(readOnly = true)
     public List<StudentHistoryRes> findStudentHistory(Long memberCode){
         return studentHistoryRepository.findByStudent_MemberCode(memberCode)
                 .stream()

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -2,6 +2,8 @@ package com.green.member.application.student;
 
 import com.green.common.enumcode.EnumMajorType;
 import com.green.common.enumcode.EnumMemberRole;
+import com.green.common.exception.AuthErrorCode;
+import com.green.common.exception.BusinessException;
 import com.green.member.application.member.MemberRepository;
 import com.green.member.application.student.model.StudentHistoryRes;
 import com.green.member.application.student.model.StudentProfileRes;
@@ -9,6 +11,7 @@ import com.green.member.entity.cache.MajorCache;
 import com.green.member.entity.member.Member;
 import com.green.member.entity.student.Student;
 import com.green.member.entity.student.StudentMajor;
+import com.green.member.exception.MemberErrorCode;
 import com.green.member.repository.MajorCacheRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,12 +33,9 @@ public class StudentService {
     // 학생 정보 조회
     @Transactional(readOnly = true)
     public StudentProfileRes findStudent(Long memberCode, EnumMemberRole role){
-        Member memberInfo = memberRepository.findById(memberCode).orElseThrow();
-        log.info("memberInfo : {}", memberInfo);
-        Student studentInfo = studentRepository.findById(memberCode).orElseThrow();
-        log.info("studentInfo: {}", studentInfo);
+        Member memberInfo = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Student studentInfo = studentRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND));
         List<StudentMajor> majors = studentMajorRepository.findByStudent_MemberCodeAndIsActiveTrue(memberCode);
-        log.info("majors: {}", majors);
 
         StudentMajor mainMajor = majors.stream()
                 .filter(m -> m.getType() == EnumMajorType.PRIMARY)
@@ -45,10 +45,10 @@ public class StudentService {
                 .filter(m -> m.getType() == EnumMajorType.MINOR)
                 .findFirst()
                 .orElse(null);
-        MajorCache mainMajorCache = majorCacheRepository.findById(mainMajor.getMajorId()).orElseThrow();
+        MajorCache mainMajorCache = majorCacheRepository.findById(mainMajor.getMajorId()).orElseThrow(() -> new BusinessException(MemberErrorCode.MAJOR_NOT_FOUND));
         String subMajorName = null;
         if (subMajor != null) {
-            MajorCache subMajorCache = majorCacheRepository.findById(subMajor.getMajorId()).orElseThrow();
+            MajorCache subMajorCache = majorCacheRepository.findById(subMajor.getMajorId()).orElseThrow(() -> new BusinessException(MemberErrorCode.MAJOR_NOT_FOUND));
             subMajorName = subMajorCache.getName();
         }
 

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -31,7 +31,6 @@ public class StudentService {
     private final StudentHistoryRepository studentHistoryRepository;
 
     // 학생 정보 조회
-    @Transactional(readOnly = true)
     public StudentProfileRes findStudent(Long memberCode, EnumMemberRole role){
         Member memberInfo = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
         Student studentInfo = studentRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND));
@@ -83,7 +82,7 @@ public class StudentService {
     // 학생 상태 변경 이력 조회
     @Transactional(readOnly = true)
     public List<StudentHistoryRes> findStudentHistory(Long memberCode){
-        return studentHistoryRepository.findByStudent_MemberCode(memberCode)
+        return studentHistoryRepository.findByStudent_MemberCodeOrderByCreatedAtDesc(memberCode)
                 .stream()
                 .map( h -> {
                     StudentHistoryRes res = new StudentHistoryRes();

--- a/member-service/src/main/java/com/green/member/exception/MemberErrorCode.java
+++ b/member-service/src/main/java/com/green/member/exception/MemberErrorCode.java
@@ -1,0 +1,20 @@
+package com.green.member.exception;
+
+import com.green.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+    MEMBER_NOT_FOUND("M001", "존재하지 않는 회원입니다.", HttpStatus.NOT_FOUND)
+    , STUDENT_NOT_FOUND("M002", "존재하지 않는 학생입니다.", HttpStatus.NOT_FOUND)
+    , PROFESSOR_NOT_FOUND("M003", "존재하지 않는 교수입니다.", HttpStatus.NOT_FOUND)
+    , ADMIN_NOT_FOUND("M004", "존재하지 않는 관리자입니다.", HttpStatus.NOT_FOUND)
+    , MAJOR_NOT_FOUND("M005", "존재하지 않는 학과입니다.", HttpStatus.NOT_FOUND)
+    ;
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}


### PR DESCRIPTION
## 관련 이슈
closes #126 

## 관련 기능
FR-MEMB-15 | 관리자 | 회원 | 회원 개인정보 변경
FR-MEMB-16 | 관리자 | 회원 | 회원 학적/직위 정보 변경
FR-MEMB-31 | 시스템 | 회원 | 계정 상태 동기화
FR-MEMB-26 | 시스템 | 회원 | 개인정보 변경 이력 기록
FR-MEMB-27 | 시스템 | 회원 | 상태 변경 이력 기록
FR-MEMB-26 | 시스템 | 회원 | 개인정보 변경 이력 기록

## 작업 내용
- 퇴사/퇴임/자퇴/퇴학의 경우 로그인 불가 상태로 변경하고 RT 삭제
- 등록 및 수정 때 오류 시 롤백되도록 애노테이션 추가
- ErrorCode 예외 처리 추가