### PR TITLE
feat(auth) 인증 도메인 모든 API 인증받지 않아도 사용할 수 있도록 설정 권한 변경 (#138)

### DIFF
--- a/auth-service/src/main/java/com/green/auth/application/auth/AdminAuthController.java
+++ b/auth-service/src/main/java/com/green/auth/application/auth/AdminAuthController.java
@@ -32,7 +32,7 @@ public class AdminAuthController {
         AuthMember loginMember = authService.login( req );
         // 학생/교수 로그인 불가
         if (loginMember.getRole() != EnumMemberRole.ADMIN) {
-            throw new BusinessException(AuthErrorCode.UNAUTHORIZED_ROLE);
+            throw new BusinessException(AuthErrorCode.LOGIN_UNAUTHORIZED_ROLE);
         }
         // 토큰에 담을 유저 정보 세팅
         JwtMember jwtMember = new JwtMember( loginMember.getMemberCode(), loginMember.getRole().getCode(), deviceType.name() );

--- a/auth-service/src/main/java/com/green/auth/application/auth/AuthController.java
+++ b/auth-service/src/main/java/com/green/auth/application/auth/AuthController.java
@@ -33,7 +33,7 @@ public class AuthController {
         AuthMember loginMember = authService.login( req );
         // 관리자가 로그인 불가
         if (loginMember.getRole() == EnumMemberRole.ADMIN) {
-            throw new BusinessException(AuthErrorCode.UNAUTHORIZED_ROLE);
+            throw new BusinessException(AuthErrorCode.LOGIN_UNAUTHORIZED_ROLE);
         }
         // 토큰에 담을 유저 정보 세팅
         JwtMember jwtMember = new JwtMember( loginMember.getMemberCode(), loginMember.getRole().getCode(), deviceType.name() );

--- a/common/src/main/java/com/green/common/exception/AuthErrorCode.java
+++ b/common/src/main/java/com/green/common/exception/AuthErrorCode.java
@@ -14,8 +14,8 @@ public enum AuthErrorCode implements ErrorCode {
     , INVALID_REFRESH_TOKEN("A005", "다시 로그인해 주세요.", HttpStatus.UNAUTHORIZED)
     , EXPIRED_TOKEN("A006", "로그인 시간이 만료되었습니다. 다시 로그인해 주세요.", HttpStatus.UNAUTHORIZED)
     , UNAUTHENTICATED("A009", "로그인이 필요합니다.", HttpStatus.UNAUTHORIZED)
-    , SAME_AS_CURRENT_PASSWORD("A007", "기존과 동일한 비밀번호 입니다.", HttpStatus.FORBIDDEN),
-    UNAUTHORIZED_ROLE("A008", "권한이 없습니다.", HttpStatus.FORBIDDEN)
+    , SAME_AS_CURRENT_PASSWORD("A007", "기존과 동일한 비밀번호 입니다.", HttpStatus.FORBIDDEN)
+    , LOGIN_UNAUTHORIZED_ROLE("A008", "로그인 권한이 없습니다.", HttpStatus.FORBIDDEN)
     ;
     private final String code;
     private final String message;

--- a/gateway/src/main/java/com/green/gateway/security/WebSecurityConfiguration.java
+++ b/gateway/src/main/java/com/green/gateway/security/WebSecurityConfiguration.java
@@ -32,8 +32,7 @@ public class WebSecurityConfiguration {
                 .cors( cors -> cors.configurationSource(corsConfigurationSource()) )
                 //인가처리 (권한처리)
                 .authorizeHttpRequests(auth -> auth
-
-                        .requestMatchers("/api/academic/public/**").permitAll() // 비로그인 가능
+                        .requestMatchers("/api/academic/public/**", "/api/auth/**").permitAll() // 비로그인 가능
 
                         // 권한별 접근 제어
                         .requestMatchers("/api/*/admin/**").hasRole(EnumMemberRole.ADMIN.name())


### PR DESCRIPTION
## 관련기능
FR-AUTH-01 | 교수, 학생 | 인증 | 로그인
FR-AUTH-02 | 관리자 | 인증 | 관리자 로그인

## 관련 이슈 
close #138 

## 작업내용
- /admin 이 URL에 포함되면 무조건 로그인 권한이 있어 관리자 로그인이 막히는 문제 발생
- 인증 도메인 모든 API은 인가처리 없이 가능하도록 확인 최우선으로 변경