### PR TITLE
fix(member) 회원 단건 등록 기능 유효성 검사 및 누락 사항 추가 #153

### DIFF
--- a/common/src/main/java/com/green/common/enumcode/EnumBuilding.java
+++ b/common/src/main/java/com/green/common/enumcode/EnumBuilding.java
@@ -30,7 +30,7 @@ public enum EnumBuilding implements EnumMapperType {
 
     @JsonCreator
     public static EnumBuilding from(String value) {
-        if (value == null) return null;
+        if (value == null || value.isBlank()) return null;
 
         for (EnumBuilding building : EnumBuilding.values()) {
             // 1. 한글 명칭("인문관")으로 비교

--- a/common/src/main/java/com/green/common/enumcode/EnumProfessorDegree.java
+++ b/common/src/main/java/com/green/common/enumcode/EnumProfessorDegree.java
@@ -13,6 +13,7 @@ public enum EnumProfessorDegree implements EnumMapperType {
 
     @JsonCreator
     public static EnumProfessorDegree from(String value) {
+        if (value == null || value.isBlank()) return null;
         for (EnumProfessorDegree degree : EnumProfessorDegree.values()) {
             if (degree.getCode().equalsIgnoreCase(value)) {
                 return degree;

--- a/common/src/main/java/com/green/common/enumcode/EnumProfessorStatus.java
+++ b/common/src/main/java/com/green/common/enumcode/EnumProfessorStatus.java
@@ -15,6 +15,7 @@ public enum EnumProfessorStatus implements EnumMapperType {
 
     @JsonCreator
     public static EnumProfessorStatus from(String value) {
+        if (value == null || value.isBlank()) return null;
         for (EnumProfessorStatus status : EnumProfessorStatus.values()) {
             if (status.getCode().equalsIgnoreCase(value)) {
                 return status;

--- a/common/src/main/java/com/green/common/enumcode/EnumStudentStatus.java
+++ b/common/src/main/java/com/green/common/enumcode/EnumStudentStatus.java
@@ -20,6 +20,7 @@ public enum EnumStudentStatus implements EnumMapperType {
 
     @JsonCreator
     public static EnumStudentStatus from(String value) {
+        if (value == null || value.isBlank()) return null;
         for (EnumStudentStatus status : EnumStudentStatus.values()) {
             if (status.getCode().equalsIgnoreCase(value)) {
                 return status;

--- a/common/src/main/java/com/green/common/exception/CommonErrorCode.java
+++ b/common/src/main/java/com/green/common/exception/CommonErrorCode.java
@@ -14,6 +14,7 @@ public enum CommonErrorCode  implements ErrorCode {
     , GATEWAY_INTERNAL_ERROR("C005", "게이트웨이 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
     , NOT_FOUND_PATH("C007", "존재하지 않는 경로입니다.", HttpStatus.NOT_FOUND)
     , DUPLICATE_ENTRY("C008", "이미 존재하는 데이터입니다.", HttpStatus.CONFLICT)
+    , NULL_CONSTRAINT_VIOLATION("C009", "필수 항목이 누락되었습니다.", HttpStatus.BAD_REQUEST)
     ;
 
     private final String code;

--- a/common/src/main/java/com/green/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/green/common/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -31,6 +32,15 @@ import java.util.List;
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    // JSON 파싱 실패 (잘못된 enum 값, 타입 불일치 등)
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex,
+            HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.warn("HttpMessageNotReadableException: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ResultResponse<>("요청 데이터 형식이 올바르지 않습니다.", null));
+    }
 
     //Validation 예외가 발생되었을 때 캐치
     //입력값 검증 실패 시 호출. 여러 에러 중 첫 번째 에러 메시지만 추출하여 반환
@@ -135,6 +145,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<ResultResponse<String>> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
         log.error("DataIntegrityViolationException: {}", ex.getMessage());
+        String msg = ex.getMessage();
+        if (msg != null && msg.contains("cannot be null")) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ResultResponse<>(CommonErrorCode.NULL_CONSTRAINT_VIOLATION.getMessage(), null));
+        }
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(new ResultResponse<>(CommonErrorCode.DUPLICATE_ENTRY.getMessage(), null));
     }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminBatchService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminBatchService.java
@@ -1,5 +1,6 @@
 package com.green.member.application.admin;
 
+import com.green.common.auth.MemberContext;
 import com.green.member.application.admin.model.AdminCreateReq;
 import com.green.member.application.admin.model.FailRowRes;
 import com.green.member.application.member.MemberBatchService;
@@ -66,6 +67,6 @@ public class AdminBatchService extends MemberBatchService<AdminCreateReq> {
 
     @Override
     protected void save(AdminCreateReq req) {
-        adminService.createAdmin(req, null);
+        adminService.createAdmin(req, null, MemberContext.get().memberCode());
     }
 }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -14,9 +14,11 @@ import com.green.member.application.student.StudentBatchService;
 import com.green.member.application.student.model.StatusUpdateStudentReq;
 import com.green.member.application.student.model.StudentCreateReq;
 import com.green.member.application.student.model.StudentListDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -127,32 +129,36 @@ public class AdminController {
                 .build();
     }
 
+    // 학생 단건 등록
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/students")
-    public ResultResponse<?> createStudent(@RequestPart StudentCreateReq req,
+    public ResultResponse<?> createStudent(@RequestPart @Valid StudentCreateReq req,
                                            @RequestPart(required = false) MultipartFile pic) {
         MemberCreateRes res = adminService.createStudent(req, pic);
         return ResultResponse.builder()
-                .message("학생 정보 등록 성공")
+                .message("학생 정보 등록 성공했습니다")
                 .data(res)
                 .build();
     }
-
+    // 교수 단건 등록
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/professors")
-    public ResultResponse<?> createProfessor(@RequestPart ProfessorCreateReq req,
+    public ResultResponse<?> createProfessor(@RequestPart @Valid ProfessorCreateReq req,
                                              @RequestPart(required = false) MultipartFile pic) {
         MemberCreateRes res = adminService.createProfessor(req, pic);
         return ResultResponse.builder()
-                .message("교수 정보 등록 성공")
+                .message("교수 정보 등록 성공했습니다")
                 .data(res)
                 .build();
     }
-
+    // 관리자 단건 등록
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/admins")
-    public ResultResponse<?> createAdmin(@RequestPart AdminCreateReq req,
+    public ResultResponse<?> createAdmin(@RequestPart @Valid AdminCreateReq req,
                                          @RequestPart(required = false) MultipartFile pic) {
         MemberCreateRes res = adminService.createAdmin(req, pic);
         return ResultResponse.builder()
-                .message("관리자 정보 등록 성공")
+                .message("관리자 정보 등록 성공했습니다")
                 .data(res)
                 .build();
     }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -105,6 +105,7 @@ public class AdminController {
     }
 
     // 학생 일괄 등록
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/students/batch")
     public ResultResponse<?> batchRegisterStudents(@RequestParam("file") MultipartFile file) throws IOException {
         return ResultResponse.builder()
@@ -113,6 +114,7 @@ public class AdminController {
                 .build();
     }
     // 교수 일괄 등록
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/professors/batch")
     public ResultResponse<?> batchRegisterProfessors(@RequestParam("file") MultipartFile file) throws IOException {
         return ResultResponse.builder()
@@ -121,6 +123,7 @@ public class AdminController {
                 .build();
     }
     // 관리자 일괄 등록
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/admins/batch")
     public ResultResponse<?> batchRegisterAdmins(@RequestParam("file") MultipartFile file) throws IOException {
         return ResultResponse.builder()
@@ -134,7 +137,8 @@ public class AdminController {
     @PostMapping("/students")
     public ResultResponse<?> createStudent(@RequestPart @Valid StudentCreateReq req,
                                            @RequestPart(required = false) MultipartFile pic) {
-        MemberCreateRes res = adminService.createStudent(req, pic);
+        MemberDto loginMember = MemberContext.get();
+        MemberCreateRes res = adminService.createStudent(req, pic, loginMember.memberCode());
         return ResultResponse.builder()
                 .message("학생 정보 등록 성공했습니다")
                 .data(res)
@@ -145,7 +149,8 @@ public class AdminController {
     @PostMapping("/professors")
     public ResultResponse<?> createProfessor(@RequestPart @Valid ProfessorCreateReq req,
                                              @RequestPart(required = false) MultipartFile pic) {
-        MemberCreateRes res = adminService.createProfessor(req, pic);
+        MemberDto loginMember = MemberContext.get();
+        MemberCreateRes res = adminService.createProfessor(req, pic, loginMember.memberCode());
         return ResultResponse.builder()
                 .message("교수 정보 등록 성공했습니다")
                 .data(res)
@@ -156,7 +161,8 @@ public class AdminController {
     @PostMapping("/admins")
     public ResultResponse<?> createAdmin(@RequestPart @Valid AdminCreateReq req,
                                          @RequestPart(required = false) MultipartFile pic) {
-        MemberCreateRes res = adminService.createAdmin(req, pic);
+        MemberDto loginMember = MemberContext.get();
+        MemberCreateRes res = adminService.createAdmin(req, pic, loginMember.memberCode());
         return ResultResponse.builder()
                 .message("관리자 정보 등록 성공했습니다")
                 .data(res)

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -163,7 +163,7 @@ public class AdminService {
 
     // 학생 정보 추가
     @Transactional
-    public MemberCreateRes createStudent(StudentCreateReq req, MultipartFile pic) {
+    public MemberCreateRes createStudent(StudentCreateReq req, MultipartFile pic, Long updaterCode) {
         Member member = createMember(req, pic, EnumMemberRole.STUDENT);
 
         // 학생 테이블 저장
@@ -188,6 +188,17 @@ public class AdminService {
 
         StudentMajor savedStudentMajor = studentMajorRepository.save(studentMajor);
 
+        // 입학 이력 저장 (신규입학 / 편입학 구분)
+        String changeType = savedStudent.getIsTransfer() ? "편입학" : "신규입학";
+        studentHistoryRepository.save(StudentHistory.builder()
+                .student(savedStudent)
+                .changeType(changeType)
+                .oldStatus(null)
+                .newStatus(savedStudent.getStatus())
+                .startDate(member.getEntryDate())
+                .updatorCode(updaterCode)
+                .build());
+
         // StudentEvent Outbox 저장
         StudentEvent studentEvent = StudentEvent.builder()
                 .memberCode(member.getMemberCode())
@@ -211,7 +222,7 @@ public class AdminService {
 
     // 교수 정보 추가
     @Transactional
-    public MemberCreateRes createProfessor(ProfessorCreateReq req, MultipartFile pic) {
+    public MemberCreateRes createProfessor(ProfessorCreateReq req, MultipartFile pic, Long updaterCode) {
         Member member = createMember(req, pic, EnumMemberRole.PROFESSOR);
 
         Professor newProfessor = Professor.builder()
@@ -226,6 +237,17 @@ public class AdminService {
                 .build();
 
         Professor savedProfessor = professorRepository.save(newProfessor);
+
+        // 신규임용 이력 저장
+        professorHistoryRepository.save(ProfessorHistory.builder()
+                .professor(savedProfessor)
+                .changeType("신규임용")
+                .oldStatus(null)
+                .newStatus(savedProfessor.getStatus())
+                .newPosition(savedProfessor.getPosition())
+                .startDate(member.getEntryDate())
+                .updatorCode(updaterCode)
+                .build());
 
         // ProfessorEvent Outbox 저장
         ProfessorEvent professorEvent = ProfessorEvent.builder()
@@ -246,7 +268,7 @@ public class AdminService {
 
     // 관리자 정보 추가
     @Transactional
-    public MemberCreateRes createAdmin(AdminCreateReq req, MultipartFile pic) {
+    public MemberCreateRes createAdmin(AdminCreateReq req, MultipartFile pic, Long updaterCode) {
         Member member = createMember(req, pic, EnumMemberRole.ADMIN);
 
         Admin newAdmin = Admin.builder()
@@ -254,7 +276,17 @@ public class AdminService {
                 .status(req.getStatus())
                 .build();
 
-        adminRepository.save(newAdmin);
+        Admin savedAdmin = adminRepository.save(newAdmin);
+
+        // 신규입사 이력 저장
+        adminHistoryRepository.save(AdminHistory.builder()
+                .admin(savedAdmin)
+                .changeType("신규입사")
+                .oldStatus(null)
+                .newStatus(savedAdmin.getStatus())
+                .startDate(member.getEntryDate())
+                .updatorCode(updaterCode)
+                .build());
 
         return MemberCreateRes.builder()
                 .memberCode(member.getMemberCode())

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -82,7 +82,7 @@ public class AdminService {
         return adminRepository.findAdminList();
     }
 
-    // 회원 정보 추가. 공통 처리: member 저장 + memberCode 생성
+    // 회원 계정 등록. 공통 처리: member 저장 + memberCode 생성
     private Member createMember(MemberCreateReq req, MultipartFile pic, EnumMemberRole role) {
         // 파일 처리
         String savedPicFileName = pic == null ? null : myFileUtil.makeRandomFileName(pic);
@@ -92,6 +92,11 @@ public class AdminService {
 
         // 배치 등록 시 이전 행의 INSERT가 반영된 상태에서 순번을 계산하도록 명시적 플러시
         memberRepository.flush();
+
+        // 이미 등록된 이메일인지 검사
+        if( memberRepository.existsByEmail(req.getEmail()) ){
+            throw new BusinessException(MemberErrorCode.DUPLICATE_EMAIL);
+        }
 
         // 순번 조회
         int seq = switch (role) {
@@ -169,7 +174,7 @@ public class AdminService {
                 .isTransfer(req.getIsTransfer() != null ? req.getIsTransfer() : false)
                 .isMultiChild(req.getIsMultiChild() != null ? req.getIsMultiChild() : false)
                 .isVeteran(req.getIsVeteran() != null ? req.getIsVeteran() : false)
-                .status(req.getStatus() != null ? req.getStatus() : EnumStudentStatus.UNREGISTERED)
+                .status(req.getStatus())
                 .build();
 
         Student savedStudent = studentRepository.save(newStudent);
@@ -213,11 +218,11 @@ public class AdminService {
                 .member(member)
                 .majorId(req.getMajorId())
                 .degree(req.getDegree())
-                .position(req.getPosition() != null ? req.getPosition() : EnumProfessorPosition.PROFESSOR)
+                .position(req.getPosition())
                 .labBuilding(req.getLabBuilding())
                 .labRoom(req.getLabRoom())
                 .labTel(req.getLabTel())
-                .status(req.getStatus() != null ? req.getStatus() : EnumProfessorStatus.EMPLOYMENT)
+                .status(req.getStatus())
                 .build();
 
         Professor savedProfessor = professorRepository.save(newProfessor);
@@ -246,7 +251,7 @@ public class AdminService {
 
         Admin newAdmin = Admin.builder()
                 .member(member)
-                .status(req.getStatus() != null ? req.getStatus() : EnumAdminStatus.EMPLOYMENT)
+                .status(req.getStatus())
                 .build();
 
         adminRepository.save(newAdmin);

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -163,7 +163,7 @@ public class AdminService {
 
     // 학생 정보 추가
     @Transactional
-    public MemberCreateRes createStudent(StudentCreateReq req, MultipartFile pic) {
+    public MemberCreateRes createStudent(StudentCreateReq req, MultipartFile pic, Long updaterCode) {
         Member member = createMember(req, pic, EnumMemberRole.STUDENT);
 
         // 학생 테이블 저장
@@ -188,6 +188,16 @@ public class AdminService {
 
         StudentMajor savedStudentMajor = studentMajorRepository.save(studentMajor);
 
+        // 신규입학 이력 저장
+        studentHistoryRepository.save(StudentHistory.builder()
+                .student(savedStudent)
+                .changeType("신규입학")
+                .oldStatus(null)
+                .newStatus(savedStudent.getStatus())
+                .startDate(member.getEntryDate())
+                .updatorCode(updaterCode)
+                .build());
+
         // StudentEvent Outbox 저장
         StudentEvent studentEvent = StudentEvent.builder()
                 .memberCode(member.getMemberCode())
@@ -211,7 +221,7 @@ public class AdminService {
 
     // 교수 정보 추가
     @Transactional
-    public MemberCreateRes createProfessor(ProfessorCreateReq req, MultipartFile pic) {
+    public MemberCreateRes createProfessor(ProfessorCreateReq req, MultipartFile pic, Long updaterCode) {
         Member member = createMember(req, pic, EnumMemberRole.PROFESSOR);
 
         Professor newProfessor = Professor.builder()
@@ -226,6 +236,17 @@ public class AdminService {
                 .build();
 
         Professor savedProfessor = professorRepository.save(newProfessor);
+
+        // 신규임용 이력 저장
+        professorHistoryRepository.save(ProfessorHistory.builder()
+                .professor(savedProfessor)
+                .changeType("신규임용")
+                .oldStatus(null)
+                .newStatus(savedProfessor.getStatus())
+                .newPosition(savedProfessor.getPosition())
+                .startDate(member.getEntryDate())
+                .updatorCode(updaterCode)
+                .build());
 
         // ProfessorEvent Outbox 저장
         ProfessorEvent professorEvent = ProfessorEvent.builder()
@@ -246,7 +267,7 @@ public class AdminService {
 
     // 관리자 정보 추가
     @Transactional
-    public MemberCreateRes createAdmin(AdminCreateReq req, MultipartFile pic) {
+    public MemberCreateRes createAdmin(AdminCreateReq req, MultipartFile pic, Long updaterCode) {
         Member member = createMember(req, pic, EnumMemberRole.ADMIN);
 
         Admin newAdmin = Admin.builder()
@@ -254,7 +275,17 @@ public class AdminService {
                 .status(req.getStatus())
                 .build();
 
-        adminRepository.save(newAdmin);
+        Admin savedAdmin = adminRepository.save(newAdmin);
+
+        // 신규입사 이력 저장
+        adminHistoryRepository.save(AdminHistory.builder()
+                .admin(savedAdmin)
+                .changeType("신규입사")
+                .oldStatus(null)
+                .newStatus(savedAdmin.getStatus())
+                .startDate(member.getEntryDate())
+                .updatorCode(updaterCode)
+                .build());
 
         return MemberCreateRes.builder()
                 .memberCode(member.getMemberCode())

--- a/member-service/src/main/java/com/green/member/application/admin/model/AdminCreateReq.java
+++ b/member-service/src/main/java/com/green/member/application/admin/model/AdminCreateReq.java
@@ -2,6 +2,7 @@ package com.green.member.application.admin.model;
 
 import com.green.member.application.member.model.MemberCreateReq;
 import com.green.member.enumcode.EnumAdminStatus;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -10,5 +11,6 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class AdminCreateReq extends MemberCreateReq {
+    @NotNull(message = "현재 상태는 필수입니다.")
     private EnumAdminStatus status;
 }

--- a/member-service/src/main/java/com/green/member/application/member/MemberRepository.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository  extends JpaRepository<Member, Long> {
+    boolean existsByEmail(String email);
+
     @Query("""
         SELECT COUNT(s) + 1
         FROM Student s

--- a/member-service/src/main/java/com/green/member/application/member/model/MemberCreateReq.java
+++ b/member-service/src/main/java/com/green/member/application/member/model/MemberCreateReq.java
@@ -1,5 +1,10 @@
 package com.green.member.application.member.model;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -8,15 +13,27 @@ import java.time.LocalDate;
 @Data
 @NoArgsConstructor
 public class MemberCreateReq {
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
+
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(max = 20, message = "이름은 최대 20자입니다.")
     private String name;
+
+    @NotNull(message = "생년월일은 필수입니다.")
+    @Past(message = "생년월일은 과거 날짜여야 합니다.")
     private LocalDate birth;
+
     private String tel;
     private String emergencyTel;
     private String postcode;
     private String address;
     private String detailAddress;
+
+    @NotNull(message = "입학/입사일은 필수입니다.")
     private LocalDate entryDate;
+
     private LocalDate exitDate;
     private String pic;
 }

--- a/member-service/src/main/java/com/green/member/application/professor/ProfessorBatchService.java
+++ b/member-service/src/main/java/com/green/member/application/professor/ProfessorBatchService.java
@@ -1,5 +1,6 @@
 package com.green.member.application.professor;
 
+import com.green.common.auth.MemberContext;
 import com.green.common.enumcode.EnumProfessorDegree;
 import com.green.common.enumcode.EnumProfessorStatus;
 import com.green.member.application.admin.AdminService;
@@ -147,7 +148,7 @@ public class ProfessorBatchService extends MemberBatchService<ProfessorCreateReq
 
     @Override
     protected void save(ProfessorCreateReq req) {
-        adminService.createProfessor(req, null);
+        adminService.createProfessor(req, null, MemberContext.get().memberCode());
     }
 
     private EnumProfessorPosition parsePosition(String value) {

--- a/member-service/src/main/java/com/green/member/application/professor/model/ProfessorCreateReq.java
+++ b/member-service/src/main/java/com/green/member/application/professor/model/ProfessorCreateReq.java
@@ -1,19 +1,30 @@
 package com.green.member.application.professor.model;
 
 import com.green.common.enumcode.EnumBuilding;
+import com.green.common.enumcode.EnumProfessorDegree;
 import com.green.common.enumcode.EnumProfessorStatus;
 import com.green.member.application.member.model.MemberCreateReq;
-import com.green.common.enumcode.EnumProfessorDegree;
 import com.green.member.enumcode.EnumProfessorPosition;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 public class ProfessorCreateReq extends MemberCreateReq {
+
+    @NotNull(message = "전공 ID는 필수입니다.")
     private Long majorId;
+
+    @NotNull(message = "최종 학위는 필수입니다.")
     private EnumProfessorDegree degree;
+
+    @NotNull(message = "현재 직위 필수입니다.")
     private EnumProfessorPosition position;
     private EnumBuilding labBuilding;
     private String labRoom;
     private String labTel;
+
+    @NotNull(message = "현재 상태는 필수입니다.")
     private EnumProfessorStatus status;
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentBatchService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentBatchService.java
@@ -1,5 +1,6 @@
 package com.green.member.application.student;
 
+import com.green.common.auth.MemberContext;
 import com.green.common.enumcode.EnumStudentStatus;
 import com.green.member.application.admin.AdminService;
 import com.green.member.application.admin.model.FailRowRes;
@@ -111,6 +112,6 @@ public class StudentBatchService extends MemberBatchService<StudentCreateReq> {
 
     @Override
     protected void save(StudentCreateReq req) {
-        adminService.createStudent(req, null);
+        adminService.createStudent(req, null, MemberContext.get().memberCode());
     }
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentBatchService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentBatchService.java
@@ -111,6 +111,6 @@ public class StudentBatchService extends MemberBatchService<StudentCreateReq> {
 
     @Override
     protected void save(StudentCreateReq req) {
-        adminService.createStudent(req, null);
+        adminService.createStudent(req, null, MemberContext.get().memberCode());
     }
 }

--- a/member-service/src/main/java/com/green/member/application/student/model/StudentCreateReq.java
+++ b/member-service/src/main/java/com/green/member/application/student/model/StudentCreateReq.java
@@ -2,17 +2,33 @@ package com.green.member.application.student.model;
 
 import com.green.common.enumcode.EnumStudentStatus;
 import com.green.member.application.member.model.MemberCreateReq;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
 public class StudentCreateReq extends MemberCreateReq {
+
+    @NotNull(message = "전공 ID는 필수입니다.")
     private Long majorId;
+
+    @NotNull(message = "학년은 필수입니다.")
+    @Min(value = 1, message = "학년은 1 이상이어야 합니다.")
+    @Max(value = 6, message = "학년은 6 이하여야 합니다.")
     private Integer academicYear;
+
+    @NotNull(message = "학기는 필수입니다.")
+    @Min(value = 1, message = "학기는 1 또는 2여야 합니다.")
+    @Max(value = 2, message = "학기는 1 또는 2여야 합니다.")
     private Integer semester;
+
     private Boolean isTransfer;
     private Boolean isMultiChild;
     private Boolean isVeteran;
+
+    @NotNull(message = "현재 상태는 필수입니다.")
     private EnumStudentStatus status;
 }

--- a/member-service/src/main/java/com/green/member/entity/member/AdminHistory.java
+++ b/member-service/src/main/java/com/green/member/entity/member/AdminHistory.java
@@ -2,6 +2,7 @@ package com.green.member.entity.member;
 
 import com.green.common.entity.CreatedAt;
 import com.green.member.enumcode.EnumAdminStatus;
+import com.green.member.enumcode.NullableAdminStatusConverter;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import lombok.*;
@@ -27,7 +28,8 @@ public class AdminHistory extends CreatedAt {
     @Column(name = "change_type", nullable = false, length = 20)
     private String changeType; //휴직, 복직
 
-    @Column(name = "old_status", nullable = false, length = 20)
+    @Convert(converter = NullableAdminStatusConverter.class)
+    @Column(name = "old_status", length = 20)
     private EnumAdminStatus oldStatus;
 
     @Column(name = "new_status", nullable = false, length = 20)

--- a/member-service/src/main/java/com/green/member/entity/professor/Professor.java
+++ b/member-service/src/main/java/com/green/member/entity/professor/Professor.java
@@ -6,6 +6,8 @@ import com.green.member.entity.member.Member;
 import com.green.common.enumcode.EnumProfessorDegree;
 import com.green.member.enumcode.EnumProfessorPosition;
 import com.green.common.enumcode.EnumProfessorStatus;
+import com.green.member.enumcode.NullableBuildingConverter;
+import com.green.member.enumcode.NullableProfessorStatusConverter;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -36,7 +38,8 @@ public class Professor extends UpdatedAt {
     @Builder.Default
     private EnumProfessorPosition position = EnumProfessorPosition.PROFESSOR;
 
-    @Column(name = "lab_building", nullable = false, length = 30)
+    @Convert(converter = NullableBuildingConverter.class)
+    @Column(name = "lab_building", length = 30)
     private EnumBuilding labBuilding;
 
     @Column(name = "lab_room", length = 20)

--- a/member-service/src/main/java/com/green/member/entity/student/StudentHistory.java
+++ b/member-service/src/main/java/com/green/member/entity/student/StudentHistory.java
@@ -2,6 +2,8 @@ package com.green.member.entity.student;
 
 import com.green.common.entity.CreatedAt;
 import com.green.common.enumcode.EnumStudentStatus;
+import com.green.member.enumcode.NullableProfessorStatusConverter;
+import com.green.member.enumcode.NullableStudentStatusConverter;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import lombok.*;
@@ -27,7 +29,8 @@ public class StudentHistory extends CreatedAt {
     @Column(name = "change_type", nullable = false, length = 20)
     private String changeType; // 신입학, 휴학, 복학, 자퇴
 
-    @Column(name = "old_status", nullable = false, length = 20)
+    @Convert(converter = NullableStudentStatusConverter.class)
+    @Column(name = "old_status", length = 20)
     private EnumStudentStatus oldStatus;
 
     @Column(name = "new_status", nullable = false, length = 20)

--- a/member-service/src/main/java/com/green/member/enumcode/EnumAdminStatus.java
+++ b/member-service/src/main/java/com/green/member/enumcode/EnumAdminStatus.java
@@ -16,6 +16,7 @@ public enum EnumAdminStatus implements EnumMapperType {
 
     @JsonCreator
     public static EnumAdminStatus from(String value) {
+        if (value == null || value.isBlank()) return null;
         for (EnumAdminStatus status : EnumAdminStatus.values()) {
             if (status.getCode().equalsIgnoreCase(value)) {
                 return status;

--- a/member-service/src/main/java/com/green/member/enumcode/EnumProfessorPosition.java
+++ b/member-service/src/main/java/com/green/member/enumcode/EnumProfessorPosition.java
@@ -19,6 +19,7 @@ public enum EnumProfessorPosition implements EnumMapperType {
 
     @JsonCreator
     public static EnumProfessorPosition from(String value) {
+        if (value == null || value.isBlank()) return null;
         for (EnumProfessorPosition position : EnumProfessorPosition.values()) {
             if (position.getCode().equalsIgnoreCase(value)) {
                 return position;

--- a/member-service/src/main/java/com/green/member/enumcode/NullableAdminStatusConverter.java
+++ b/member-service/src/main/java/com/green/member/enumcode/NullableAdminStatusConverter.java
@@ -1,0 +1,12 @@
+package com.green.member.enumcode;
+
+import com.green.common.enumcode.AbstractEnumCodeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class NullableAdminStatusConverter
+        extends AbstractEnumCodeConverter<EnumAdminStatus> {
+    public NullableAdminStatusConverter() {
+        super(EnumAdminStatus.class, true);
+    }
+}

--- a/member-service/src/main/java/com/green/member/enumcode/NullableBuildingConverter.java
+++ b/member-service/src/main/java/com/green/member/enumcode/NullableBuildingConverter.java
@@ -1,0 +1,13 @@
+package com.green.member.enumcode;
+
+import com.green.common.enumcode.AbstractEnumCodeConverter;
+import com.green.common.enumcode.EnumBuilding;
+import jakarta.persistence.Converter;
+
+@Converter
+public class NullableBuildingConverter
+        extends AbstractEnumCodeConverter<EnumBuilding> {
+    public NullableBuildingConverter() {
+        super(EnumBuilding.class, true);
+    }
+}

--- a/member-service/src/main/java/com/green/member/enumcode/NullableStudentStatusConverter.java
+++ b/member-service/src/main/java/com/green/member/enumcode/NullableStudentStatusConverter.java
@@ -1,0 +1,13 @@
+package com.green.member.enumcode;
+
+import com.green.common.enumcode.AbstractEnumCodeConverter;
+import com.green.common.enumcode.EnumStudentStatus;
+import jakarta.persistence.Converter;
+
+@Converter
+public class NullableStudentStatusConverter
+        extends AbstractEnumCodeConverter<EnumStudentStatus> {
+    public NullableStudentStatusConverter() {
+        super(EnumStudentStatus.class, true);
+    }
+}

--- a/member-service/src/main/java/com/green/member/exception/MemberErrorCode.java
+++ b/member-service/src/main/java/com/green/member/exception/MemberErrorCode.java
@@ -13,6 +13,7 @@ public enum MemberErrorCode implements ErrorCode {
     , PROFESSOR_NOT_FOUND("M003", "존재하지 않는 교수입니다.", HttpStatus.NOT_FOUND)
     , ADMIN_NOT_FOUND("M004", "존재하지 않는 관리자입니다.", HttpStatus.NOT_FOUND)
     , MAJOR_NOT_FOUND("M005", "존재하지 않는 학과입니다.", HttpStatus.NOT_FOUND)
+    , DUPLICATE_EMAIL("M006", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT)
     ;
     private final String code;
     private final String message;


### PR DESCRIPTION
## 관련 이슈 #153 

## 관련 기능
FR-MEMB-11 | 회원 | 회원 등록
학생 회원 등록
교수 회원 등록
관리자 회원 등록

## 작업 내용
- RequestDto에 NotNull 추가
- 회원 등록 시 신규 이력 자동 기록
    - 학생 등록 → student_history 신규입학/편입학(isTransfer 기반 분기)
    - 교수 등록 → professor_history 신규임용
    - 관리자 등록 → admin_history 신규입사
    - 등록자(updatorCode) 컨트롤러에서 MemberContext로 전달하도록 변경
- 이메일 중복 사전 검사 추가
    - DB 제약 예외 의존 → existsByEmail() 명시적 검사 + DUPLICATE_EMAIL(M006) 에러코드 추가
    - null/빈 문자열 수신 시 예외 발생하던 문제 수정 (EnumBuilding 외 5개)
    - 빈 문자열 → null 반환, @NotNull 필드면 Validation이 명확한 메시지로 처리
- DataIntegrityViolationException 에러 메시지 분리
    - NOT NULL 위반도 "이미 존재하는 데이터"로 반환되던 문제 수정
    - cannot be null 포함 시 400 + NULL_CONSTRAINT_VIOLATION(C009) 반환
- HttpMessageNotReadableException 응답 형식 통일
    - Spring 기본 ProblemDetail 포맷으로 반환되던 문제 수정
    - ResultResponse 형식으로 오버라이드
- DB 스키마 변경
    - student_history.old_status NOT NULL → NULL 허용 (신규 등록 시 이전 상태 없음)
    - admin_history.old_status NOT NULL → NULL 허용
    - professor.lab_building NOT NULL → NULL 허용 (선택 입력 필드)

