### PR TITLE
fix(member) 관리자의 회원 정보 수정 로직 개선

### DIFF
--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -213,9 +213,9 @@ public class AdminController {
 
     // 관리자 계정 정보 수정
     @PatchMapping("/admins/{memberCode}")
-    public ResultResponse<?> updateProfile(@PathVariable Long memberCode,
-                                           @RequestPart AdminMemberUpdateReq req,
-                                           @RequestPart(required = false) MultipartFile pic) {
+    public ResultResponse<?> updateAdminProfile(@PathVariable Long memberCode,
+                                                @RequestPart AdminMemberUpdateReq req,
+                                                @RequestPart(required = false) MultipartFile pic) {
         MemberDto loginMember = MemberContext.get();
         adminService.updateAdmin(memberCode, loginMember.memberCode(), req, pic);
         return ResultResponse.builder()
@@ -224,9 +224,9 @@ public class AdminController {
     }
     // 교수 계정 정보 수정
     @PatchMapping("/professors/{memberCode}")
-    public ResultResponse<?> updateProfile(@PathVariable Long memberCode,
-                                           @RequestPart AdminProfessorUpdateReq req,
-                                           @RequestPart(required = false) MultipartFile pic) {
+    public ResultResponse<?> updateProfessorProfile(@PathVariable Long memberCode,
+                                                    @RequestPart AdminProfessorUpdateReq req,
+                                                    @RequestPart(required = false) MultipartFile pic) {
         MemberDto loginMember = MemberContext.get();
         adminService.updateProfessor(memberCode, loginMember.memberCode(), req, pic);
         return ResultResponse.builder()
@@ -235,9 +235,9 @@ public class AdminController {
     }
     // 학생 계정 정보 수정
     @PatchMapping("/students/{memberCode}")
-    public ResultResponse<?> updateProfile(@PathVariable Long memberCode,
-                                           @RequestPart AdminStudentUpdateReq req,
-                                           @RequestPart(required = false) MultipartFile pic) {
+    public ResultResponse<?> updateStudentProfile(@PathVariable Long memberCode,
+                                                  @RequestPart AdminStudentUpdateReq req,
+                                                  @RequestPart(required = false) MultipartFile pic) {
         MemberDto loginMember = MemberContext.get();
         adminService.updateStudent(memberCode, loginMember.memberCode(), req, pic);
         return ResultResponse.builder()
@@ -256,7 +256,7 @@ public class AdminController {
     }
     // 교수 계정 상태 변경
     @PatchMapping("/professors/{memberCode}/status")
-    public ResultResponse<?> updateStatus(@PathVariable Long memberCode, @RequestBody @Valid StatusUpdateProfessorReq req) {
+    public ResultResponse<?> updateStatus(@PathVariable Long memberCode, @RequestBody StatusUpdateProfessorReq req) {
         MemberDto loginMember = MemberContext.get();
         adminService.updateProfessorStatus(memberCode, loginMember.memberCode(), req);
         return ResultResponse.builder()

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -318,7 +318,7 @@ public class AdminService {
         Member member = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
         String oldName = member.getName();
         LocalDate oldBirth = member.getBirth();
-        member.updateCommonByAdmin( req.getName(), req.getBirth(), savePic(memberCode, pic) );
+        member.updateCommonByAdmin( req.getName(), req.getBirth(), savePic(memberCode, pic, member.getPic()) );
 
         // 학생 필드 업데이트
         Student student = studentRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND));
@@ -357,7 +357,9 @@ public class AdminService {
             currentMajorId = req.getMajorId();
             majorChanged = true;
         }
-        memberHistoryService.save(memberCode, updaterCode, before);
+        if (!before.isEmpty()) {
+            memberHistoryService.save(memberCode, updaterCode, before);
+        }
 
         // StudentEvent Outbox 저장
         boolean nameChanged = req.getName() != null && !req.getName().equals(oldName);
@@ -387,7 +389,7 @@ public class AdminService {
         Member member = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
         String oldName = member.getName();
         LocalDate oldBirth = member.getBirth();
-        member.updateCommonByAdmin( req.getName(), req.getBirth(), savePic(memberCode, pic) );
+        member.updateCommonByAdmin( req.getName(), req.getBirth(), savePic(memberCode, pic, member.getPic()) );
 
         // 교수 필드 업데이트
         Professor professor = professorRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.PROFESSOR_NOT_FOUND));
@@ -401,7 +403,9 @@ public class AdminService {
         if (req.getBirth() != null && !req.getBirth().equals(oldBirth)) before.put("birth", oldBirth);
         if (req.getDegree() != null && !req.getDegree().equals(oldDegree)) before.put("degree", oldDegree);
         if (req.getMajorId() != null && !req.getMajorId().equals(oldMajorId)) before.put("majorId", oldMajorId);
-        memberHistoryService.save(memberCode, updaterCode, before);
+        if (!before.isEmpty()) {
+            memberHistoryService.save(memberCode, updaterCode, before);
+        }
 
         // ProfessorEvent Outbox 저장
         boolean nameChanged = req.getName() != null && !req.getName().equals(oldName);
@@ -423,21 +427,23 @@ public class AdminService {
     // 관리자 계정 정보 수정
     @Transactional
     public void updateAdmin(Long memberCode, Long updaterCode, AdminMemberUpdateReq req, MultipartFile pic) {
-        adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
+        Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
         Member member = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         String oldName = member.getName();
         LocalDate oldBirth = member.getBirth();
 
         // 공통 필드 업데이트
-        member.updateCommonByAdmin( req.getName(), req.getBirth(), savePic(memberCode, pic) );
+        member.updateCommonByAdmin( req.getName(), req.getBirth(), savePic(memberCode, pic, member.getPic()) );
 
         // MemberHistory 저장을 위한 변경된 필드만 수집
         Map<String, Object> before = new LinkedHashMap<>();
         if (req.getName() != null && !req.getName().equals(oldName)) before.put("name", oldName);
         if (req.getBirth() != null && !req.getBirth().equals(oldBirth)) before.put("birth", oldBirth);
 
-        memberHistoryService.save(memberCode, updaterCode, before);
+        if (!before.isEmpty()) {
+            memberHistoryService.save(memberCode, updaterCode, before);
+        }
     }
 
     @Transactional
@@ -638,6 +644,8 @@ public class AdminService {
                 .startDate(req.getStartDate())
                 .endDate(req.getEndDate())
                 .reason(req.getReason())
+                .returnYear(req.getReturnYear())
+                .returnSemester(req.getReturnSemester())
                 .updatorCode(updaterCode)
                 .build();
         studentHistoryRepository.save(history);
@@ -663,8 +671,15 @@ public class AdminService {
         }
     }
 
-    private String savePic(Long memberCode, MultipartFile pic) {
+    private String savePic(Long memberCode, MultipartFile pic, String oldFileName) {
         if (pic == null) return null;
+        if (oldFileName != null) {
+            try {
+                myFileUtil.deleteFile(String.format("member/%s/%s", memberCode, oldFileName));
+            } catch (Exception e) {
+                log.warn("기존 파일 삭제 실패: {}", e.getMessage());
+            }
+        }
         String fileName = myFileUtil.makeRandomFileName(pic);
         String middlePath = "member/" + memberCode;
         myFileUtil.makeFolders(middlePath);

--- a/member-service/src/main/java/com/green/member/application/professor/model/StatusUpdateProfessorReq.java
+++ b/member-service/src/main/java/com/green/member/application/professor/model/StatusUpdateProfessorReq.java
@@ -12,7 +12,6 @@ import java.time.LocalDate;
 @Data
 @NoArgsConstructor
 public class StatusUpdateProfessorReq {
-    @NotNull(message = "상태값은 필수입니다")
     private EnumProfessorStatus status;
     private EnumProfessorPosition position;
     private String reason;


### PR DESCRIPTION
## 관련 이슈 
closes #153

## 작업 내용
  - savePic() 메서드에 oldFileName 파라미터 추가 및 기존 프로필 사진 삭제 로직 추가
    - 관리자가 회원 사진 변경 시 기존 파일이 서버에 남는 문제 수정
    - updateStudent, updateProfessor, updateAdmin 호출부에 member.getPic() 전달
  - 변경사항이 없을 때 MemberHistory 저장 방지
    - updateStudent, updateProfessor, updateAdmin에서 before 맵이 비어있으면 저장 skip
  - updateAdmin에서 adminRepository.findById() 결과를 변수에 할당하도록 통일
    - 학생/교수 수정 메서드와 조회 패턴 일치
  - StatusUpdateProfessorReq.status의 @NotNull 제거
    - 직위(position)만 변경하는 요청이 validation에서 막히는 버그 수정
