### PR TITLE
feat(member) 학생 권한 전공 변경 신청서 작성 및 조회 (#173)

### DIFF
--- a/common/src/main/java/com/green/common/enumcode/EnumApprovalStatus.java
+++ b/common/src/main/java/com/green/common/enumcode/EnumApprovalStatus.java
@@ -11,7 +11,9 @@ import java.util.Arrays;
 public enum EnumApprovalStatus implements EnumMapperType {
     PENDING("PENDING", "대기"),
     APPROVED("APPROVED", "승인"),
-    REJECTED("REJECTED", "반려");
+    REJECTED("REJECTED", "반려"),
+    CANCELLED("CANCELLED", "취소")
+    ;
 
     private final String code;
     private final String value;

--- a/common/src/main/java/com/green/common/kafka/member/GpaRequestEvent.java
+++ b/common/src/main/java/com/green/common/kafka/member/GpaRequestEvent.java
@@ -1,0 +1,20 @@
+package com.green.common.kafka.member;
+
+import com.green.common.constants.EventType;
+import com.green.common.kafka.KafkaEvent;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GpaRequestEvent implements Serializable, KafkaEvent {
+    private Long requestId;   // MajorRequest PK (응답 매칭용)
+    private Long studentCode;
+    private EventType eventType;
+}

--- a/common/src/main/java/com/green/common/kafka/member/GpaResponseEvent.java
+++ b/common/src/main/java/com/green/common/kafka/member/GpaResponseEvent.java
@@ -1,0 +1,21 @@
+package com.green.common.kafka.member;
+
+import com.green.common.constants.EventType;
+import com.green.common.kafka.KafkaEvent;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GpaResponseEvent implements Serializable, KafkaEvent {
+    private Long requestId;   // MajorRequest PK (매칭용)
+    private BigDecimal gpa;
+    private EventType eventType;
+}

--- a/common/src/main/java/com/green/common/kafka/member/MemberTopic.java
+++ b/common/src/main/java/com/green/common/kafka/member/MemberTopic.java
@@ -4,4 +4,6 @@ public class MemberTopic {
     public static final String AUTH_MEMBER = "auth-member-events";
     public static final String STUDENT       = "student-events";
     public static final String PROFESSOR = "professor-events";
+    public static final String GPA_REQUEST  = "gpa-request-events";
+    public static final String GPA_RESPONSE = "gpa-response-events";
 }

--- a/member-service/src/main/java/com/green/member/application/student/MajorRequestRepository.java
+++ b/member-service/src/main/java/com/green/member/application/student/MajorRequestRepository.java
@@ -1,14 +1,19 @@
 package com.green.member.application.student;
 
 import com.green.common.enumcode.EnumApprovalStatus;
+import com.green.member.application.professor.model.ProfessorListDto;
+import com.green.member.application.student.model.MajorRequestRes;
 import com.green.member.entity.student.MajorRequest;
 import com.green.member.enumcode.EnumMajorRequestType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long> {
     Optional<MajorRequest> findByRequestIdAndStudent_MemberCode(Long requestId, Long memberCode);
     boolean existsByStudent_MemberCodeAndTypeAndStatus(
             Long memberCode, EnumMajorRequestType type, EnumApprovalStatus status);
+    List<MajorRequest> findByStudent_MemberCodeOrderByCreatedAtDesc(Long memberCode);
 }

--- a/member-service/src/main/java/com/green/member/application/student/MajorRequestRepository.java
+++ b/member-service/src/main/java/com/green/member/application/student/MajorRequestRepository.java
@@ -1,0 +1,7 @@
+package com.green.member.application.student;
+
+import com.green.member.entity.student.MajorRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long> {
+}

--- a/member-service/src/main/java/com/green/member/application/student/MajorRequestRepository.java
+++ b/member-service/src/main/java/com/green/member/application/student/MajorRequestRepository.java
@@ -1,7 +1,12 @@
 package com.green.member.application.student;
 
+import com.green.common.enumcode.EnumApprovalStatus;
 import com.green.member.entity.student.MajorRequest;
+import com.green.member.enumcode.EnumMajorRequestType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long> {
+
+    boolean existsByStudent_MemberCodeAndTypeAndStatus(
+            Long memberCode, EnumMajorRequestType type, EnumApprovalStatus status);
 }

--- a/member-service/src/main/java/com/green/member/application/student/MajorRequestRepository.java
+++ b/member-service/src/main/java/com/green/member/application/student/MajorRequestRepository.java
@@ -5,8 +5,10 @@ import com.green.member.entity.student.MajorRequest;
 import com.green.member.enumcode.EnumMajorRequestType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long> {
+import java.util.Optional;
 
+public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long> {
+    Optional<MajorRequest> findByRequestIdAndStudent_MemberCode(Long requestId, Long memberCode);
     boolean existsByStudent_MemberCodeAndTypeAndStatus(
             Long memberCode, EnumMajorRequestType type, EnumApprovalStatus status);
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentController.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentController.java
@@ -3,16 +3,10 @@ package com.green.member.application.student;
 import com.green.common.auth.MemberContext;
 import com.green.common.model.MemberDto;
 import com.green.common.model.ResultResponse;
-import com.green.member.application.admin.model.AdminStudentUpdateReq;
-import com.green.member.application.member.model.MemberCreateRes;
-import com.green.member.application.student.model.MajorRequestRes;
-import com.green.member.application.student.model.StudentCreateReq;
-import com.green.member.application.student.model.StudentHistoryRes;
-import com.green.member.application.student.model.StudentMajorReq;
+import com.green.member.application.student.model.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -61,6 +55,16 @@ public class StudentController {
         List<MajorRequestRes> res = studentService.findMajorRequests( loginMember.memberCode() );
         return ResultResponse.builder()
                 .message("내 전공 변경 신청 목록 조회 완료")
+                .data(res)
+                .build();
+    }
+    // 전공 변경 신청 상세 조회
+    @GetMapping("/my/major/requests/{requestId}")
+    public ResultResponse<?> findMajorRequestsDetail(@PathVariable Long requestId) {
+        MemberDto loginMember = MemberContext.get();
+        MajorRequestDetailRes res = studentService.findMajorRequest( requestId, loginMember.memberCode() );
+        return ResultResponse.builder()
+                .message("내 전공 변경 신청서 상세 조회")
                 .data(res)
                 .build();
     }

--- a/member-service/src/main/java/com/green/member/application/student/StudentController.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentController.java
@@ -36,13 +36,23 @@ public class StudentController {
 
     // 전공 변경 신청
     @PostMapping("/my/major/requests")
-    public ResultResponse<?> createStudent(@RequestPart @Valid StudentMajorReq req,
+    public ResultResponse<?> applyMajorRequest(@RequestPart @Valid StudentMajorReq req,
                                            @RequestPart(required = false) MultipartFile file) {
         MemberDto loginMember = MemberContext.get();
         studentService.requestMajor(req, file, loginMember.memberCode());
         return ResultResponse.builder()
-                .message("신청 성공했습니다")
+                .message("전공 변경 신청을 성공했습니다")
                 .build();
     }
+    // 전공 변경 신청 취소
+    @DeleteMapping("/my/major/requests/{requestId}")
+    public ResultResponse<?> deleteMajorRequest(@PathVariable("requestId") Long requestId){
+        MemberDto loginMember = MemberContext.get();
+        studentService.deleteMajorRequest(requestId, loginMember.memberCode());
+        return ResultResponse.builder()
+                .message("전공 변경 신청을 취소하였습니다")
+                .build();
+    }
+
 
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentController.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentController.java
@@ -3,12 +3,17 @@ package com.green.member.application.student;
 import com.green.common.auth.MemberContext;
 import com.green.common.model.MemberDto;
 import com.green.common.model.ResultResponse;
+import com.green.member.application.admin.model.AdminStudentUpdateReq;
+import com.green.member.application.member.model.MemberCreateRes;
+import com.green.member.application.student.model.StudentCreateReq;
 import com.green.member.application.student.model.StudentHistoryRes;
+import com.green.member.application.student.model.StudentMajorReq;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -28,4 +33,16 @@ public class StudentController {
                 .data(res)
                 .build();
     }
+
+    // 전공 변경 신청
+    @PostMapping("/my/major/requests")
+    public ResultResponse<?> createStudent(@RequestPart @Valid StudentMajorReq req,
+                                           @RequestPart(required = false) MultipartFile file) {
+        MemberDto loginMember = MemberContext.get();
+        studentService.requestMajor(req, file, loginMember.memberCode());
+        return ResultResponse.builder()
+                .message("신청 성공했습니다")
+                .build();
+    }
+
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentController.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentController.java
@@ -7,6 +7,8 @@ import com.green.member.application.student.model.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -30,7 +32,7 @@ public class StudentController {
     }
 
     // 전공 변경 신청
-    @PostMapping("/my/major/requests")
+    @PostMapping("/requests/major")
     public ResultResponse<?> applyMajorRequest(@RequestPart @Valid StudentMajorReq req,
                                            @RequestPart(required = false) MultipartFile file) {
         MemberDto loginMember = MemberContext.get();
@@ -40,7 +42,7 @@ public class StudentController {
                 .build();
     }
     // 전공 변경 신청 취소
-    @DeleteMapping("/my/major/requests/{requestId}")
+    @DeleteMapping("/requests/major/{requestId}")
     public ResultResponse<?> deleteMajorRequest(@PathVariable("requestId") Long requestId){
         MemberDto loginMember = MemberContext.get();
         studentService.deleteMajorRequest(requestId, loginMember.memberCode());
@@ -49,7 +51,7 @@ public class StudentController {
                 .build();
     }
     // 전공 변경 신청서 목록 조회
-    @GetMapping("/my/major/requests")
+    @GetMapping("/requests/major")
     public ResultResponse<?> findMajorRequests() {
         MemberDto loginMember = MemberContext.get();
         List<MajorRequestRes> res = studentService.findMajorRequests( loginMember.memberCode() );
@@ -59,7 +61,7 @@ public class StudentController {
                 .build();
     }
     // 전공 변경 신청 상세 조회
-    @GetMapping("/my/major/requests/{requestId}")
+    @GetMapping("/requests/major/{requestId}")
     public ResultResponse<?> findMajorRequestsDetail(@PathVariable Long requestId) {
         MemberDto loginMember = MemberContext.get();
         MajorRequestDetailRes res = studentService.findMajorRequest( requestId, loginMember.memberCode() );
@@ -67,5 +69,11 @@ public class StudentController {
                 .message("내 전공 변경 신청서 상세 조회")
                 .data(res)
                 .build();
+    }
+    // 전공 변경 신청서 파일 다운로드
+    @GetMapping("/requests/major/{requestId}/file")
+    public ResponseEntity<Resource> downloadMajorRequestFile(@PathVariable Long requestId) {
+        MemberDto loginMember = MemberContext.get();
+        return studentService.findMajorRequestFile(requestId, loginMember.memberCode());
     }
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentController.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentController.java
@@ -5,6 +5,7 @@ import com.green.common.model.MemberDto;
 import com.green.common.model.ResultResponse;
 import com.green.member.application.admin.model.AdminStudentUpdateReq;
 import com.green.member.application.member.model.MemberCreateRes;
+import com.green.member.application.student.model.MajorRequestRes;
 import com.green.member.application.student.model.StudentCreateReq;
 import com.green.member.application.student.model.StudentHistoryRes;
 import com.green.member.application.student.model.StudentMajorReq;
@@ -53,6 +54,14 @@ public class StudentController {
                 .message("전공 변경 신청을 취소하였습니다")
                 .build();
     }
-
-
+    // 전공 변경 신청서 목록 조회
+    @GetMapping("/my/major/requests")
+    public ResultResponse<?> findMajorRequests() {
+        MemberDto loginMember = MemberContext.get();
+        List<MajorRequestRes> res = studentService.findMajorRequests( loginMember.memberCode() );
+        return ResultResponse.builder()
+                .message("내 전공 변경 신청 목록 조회 완료")
+                .data(res)
+                .build();
+    }
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -190,7 +190,7 @@ public class StudentService {
 
         // 파일 저장
         if (file != null) {
-            String middlePath = "member/major/request/" + memberCode;
+            String middlePath = "request/major/" + memberCode;
             myFileUtil.makeFolders(middlePath);
             String fullFilePath = String.format("%s/%s", middlePath, savedFileName);
             try {
@@ -214,7 +214,7 @@ public class StudentService {
         // 첨부파일 있었다면 삭제
         if (request.getFile() != null) {
             try {
-                myFileUtil.deleteFile(String.format("member/major/request/%s/%s", memberCode, request.getFile()));
+                myFileUtil.deleteFile(String.format("request/major/%s/%s", memberCode, request.getFile()));
             } catch (Exception e) {
                 log.warn("기존 파일 삭제 실패: {}", e.getMessage());
             }

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -1,6 +1,7 @@
 package com.green.member.application.student;
 
 import com.green.common.constants.EventType;
+import com.green.common.enumcode.EnumApprovalStatus;
 import com.green.common.enumcode.EnumMajorType;
 import com.green.common.enumcode.EnumMemberRole;
 import com.green.common.exception.BusinessException;
@@ -20,6 +21,7 @@ import com.green.member.entity.student.StudentHistory;
 import com.green.member.entity.student.StudentMajor;
 import com.green.member.exception.MemberErrorCode;
 import com.green.member.application.major.MajorCacheRepository;
+import com.green.member.exception.RequestErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -124,13 +126,29 @@ public class StudentService {
         // 회원 조회
         Student student = studentRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND));
 
+        // 중복 신청 방지
+        if (majorRequestRepository.existsByStudent_MemberCodeAndTypeAndStatus(
+                memberCode, req.getType(), EnumApprovalStatus.PENDING)) {
+            throw new BusinessException(RequestErrorCode.ALREADY_PENDING_REQUEST);
+        }
+
+        // 전공 검증
+        majorCacheRepository.findById(req.getTargetMajorId()) // 존재하지 않는 학과라면
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.MAJOR_NOT_FOUND));
+        List<StudentMajor> activeMajors = studentMajorRepository.findByStudent_MemberCodeAndIsActiveTrue(memberCode);
+        boolean alreadyInMajor = activeMajors.stream()
+                .anyMatch(m -> m.getMajorId().equals(req.getTargetMajorId()));
+        if (alreadyInMajor) { // 본인의 학과를 재신청한다면
+            throw new BusinessException(RequestErrorCode.ALREADY_IN_MAJOR);
+        }
+
         // 파일 검증 및 처리
         if (file != null) {
             if (file.getSize() > 5 * 1024 * 1024) {
-                throw new BusinessException(MemberErrorCode.FILE_TOO_LARGE);
+                throw new BusinessException(RequestErrorCode.FILE_TOO_LARGE);
             }
             if (!"application/pdf".equals(file.getContentType())) {
-                throw new BusinessException(MemberErrorCode.INVALID_FILE_TYPE);
+                throw new BusinessException(RequestErrorCode.INVALID_FILE_TYPE);
             }
         }
         String savedFileName = file == null ? null : myFileUtil.makeRandomFileName(file);
@@ -157,6 +175,7 @@ public class StudentService {
                         .build()
         );
 
+        // 파일 저장
         if (file != null) {
             String middlePath = "member/major/request/" + memberCode;
             myFileUtil.makeFolders(middlePath);

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -1,13 +1,20 @@
 package com.green.member.application.student;
 
+import com.green.common.constants.EventType;
 import com.green.common.enumcode.EnumMajorType;
 import com.green.common.enumcode.EnumMemberRole;
 import com.green.common.exception.BusinessException;
+import com.green.common.kafka.member.GpaRequestEvent;
+import com.green.common.kafka.member.MemberTopic;
+import com.green.member.application.OutboxService;
 import com.green.member.application.member.MemberRepository;
 import com.green.member.application.student.model.StudentHistoryRes;
+import com.green.member.application.student.model.StudentMajorReq;
 import com.green.member.application.student.model.StudentProfileRes;
+import com.green.member.configuration.MyFileUtil;
 import com.green.member.entity.cache.MajorCache;
 import com.green.member.entity.member.Member;
+import com.green.member.entity.student.MajorRequest;
 import com.green.member.entity.student.Student;
 import com.green.member.entity.student.StudentHistory;
 import com.green.member.entity.student.StudentMajor;
@@ -17,7 +24,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.List;
 
 @Slf4j
@@ -29,6 +39,9 @@ public class StudentService {
     private final StudentRepository studentRepository;
     private final StudentMajorRepository studentMajorRepository;
     private final StudentHistoryRepository studentHistoryRepository;
+    private final MajorRequestRepository majorRequestRepository;
+    private final OutboxService outboxService;
+    private final MyFileUtil myFileUtil;
 
     // 학생 정보 조회
     public StudentProfileRes findStudent(Long memberCode, EnumMemberRole role){
@@ -103,5 +116,57 @@ public class StudentService {
                 })
                 .toList()
                 ;
+    }
+
+    // 학생 전공 변경 신청
+    @Transactional
+    public void requestMajor(StudentMajorReq req, MultipartFile file, Long memberCode){
+        // 회원 조회
+        Student student = studentRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND));
+
+        // 파일 검증 및 처리
+        if (file != null) {
+            if (file.getSize() > 5 * 1024 * 1024) {
+                throw new BusinessException(MemberErrorCode.FILE_TOO_LARGE);
+            }
+            if (!"application/pdf".equals(file.getContentType())) {
+                throw new BusinessException(MemberErrorCode.INVALID_FILE_TYPE);
+            }
+        }
+        String savedFileName = file == null ? null : myFileUtil.makeRandomFileName(file);
+
+        // major_request 저장
+        MajorRequest request = MajorRequest.builder()
+                .student(student)
+                .type(req.getType())
+                .targetMajorId(req.getTargetMajorId())
+                .reason(req.getReason())
+                .file(savedFileName)
+                .gpa(BigDecimal.ZERO)
+                .build();
+        MajorRequest newRequest = majorRequestRepository.save(request);
+
+        // GPA 조회 요청 이벤트 발행
+        outboxService.saveToOutbox(
+                MemberTopic.GPA_REQUEST,
+                newRequest.getRequestId(),
+                GpaRequestEvent.builder()
+                        .requestId(newRequest.getRequestId())
+                        .studentCode(memberCode)
+                        .eventType(EventType.E_CREATED)
+                        .build()
+        );
+
+        if (file != null) {
+            String middlePath = "member/major/request/" + memberCode;
+            myFileUtil.makeFolders(middlePath);
+            String fullFilePath = String.format("%s/%s", middlePath, savedFileName);
+            try {
+                myFileUtil.transferTo(file, fullFilePath);
+            } catch (IOException e) {
+                request.setFile(null);
+                log.error("파일 저장 실패: {}", e.getMessage());
+            }
+        }
     }
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -9,6 +9,7 @@ import com.green.common.kafka.member.GpaRequestEvent;
 import com.green.common.kafka.member.MemberTopic;
 import com.green.member.application.OutboxService;
 import com.green.member.application.member.MemberRepository;
+import com.green.member.application.schedule.SchedulePeriodValidator;
 import com.green.member.application.student.model.StudentHistoryRes;
 import com.green.member.application.student.model.StudentMajorReq;
 import com.green.member.application.student.model.StudentProfileRes;
@@ -43,6 +44,7 @@ public class StudentService {
     private final StudentHistoryRepository studentHistoryRepository;
     private final MajorRequestRepository majorRequestRepository;
     private final OutboxService outboxService;
+    private final SchedulePeriodValidator schedulePeriodValidator;
     private final MyFileUtil myFileUtil;
 
     // 학생 정보 조회
@@ -126,9 +128,11 @@ public class StudentService {
         // 회원 조회
         Student student = studentRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND));
 
+        // 전공 변경 신청 기간 체크
+        schedulePeriodValidator.checkMajorChange();
+
         // 중복 신청 방지
-        if (majorRequestRepository.existsByStudent_MemberCodeAndTypeAndStatus(
-                memberCode, req.getType(), EnumApprovalStatus.PENDING)) {
+        if (majorRequestRepository.existsByStudent_MemberCodeAndTypeAndStatus( memberCode, req.getType(), EnumApprovalStatus.PENDING)) {
             throw new BusinessException(RequestErrorCode.ALREADY_PENDING_REQUEST);
         }
 

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -9,11 +9,9 @@ import com.green.common.kafka.member.GpaRequestEvent;
 import com.green.common.kafka.member.MemberTopic;
 import com.green.member.application.OutboxService;
 import com.green.member.application.member.MemberRepository;
+import com.green.member.application.member.model.MemberProfileRes;
 import com.green.member.application.schedule.SchedulePeriodValidator;
-import com.green.member.application.student.model.MajorRequestRes;
-import com.green.member.application.student.model.StudentHistoryRes;
-import com.green.member.application.student.model.StudentMajorReq;
-import com.green.member.application.student.model.StudentProfileRes;
+import com.green.member.application.student.model.*;
 import com.green.member.configuration.MyFileUtil;
 import com.green.member.entity.cache.MajorCache;
 import com.green.member.entity.member.Member;
@@ -233,7 +231,27 @@ public class StudentService {
                     res.setCreatedAt(h.getCreatedAt());
                     return res;
                 })
-                .toList()
-                ;
+                .toList();
+    }
+    // 학생 전공 변경 신청서 상세 조회
+    @Transactional(readOnly = true)
+    public MajorRequestDetailRes findMajorRequest (Long requestId, Long memberCode){
+        MajorRequest request = majorRequestRepository.findByRequestIdAndStudent_MemberCode( requestId, memberCode )
+                .orElseThrow(() -> new BusinessException(RequestErrorCode.NOT_MAJOR_REQUEST));
+        String majorName = majorCacheRepository.findById(request.getTargetMajorId())
+                .map(MajorCache::getName)
+                .orElse(null);
+        return MajorRequestDetailRes.builder()
+                .requestId(requestId)
+                .type(request.getType())
+                .targetMajorName(majorName)
+                .status(request.getStatus())
+                .gpa(request.getGpa())
+                .reason(request.getReason())
+                .file(request.getFile())
+                .approveReason(request.getApproveReason())
+                .rejectReason(request.getRejectReason())
+                .createdAt(request.getCreatedAt())
+                .build();
     }
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -10,6 +10,7 @@ import com.green.common.kafka.member.MemberTopic;
 import com.green.member.application.OutboxService;
 import com.green.member.application.member.MemberRepository;
 import com.green.member.application.schedule.SchedulePeriodValidator;
+import com.green.member.application.student.model.MajorRequestRes;
 import com.green.member.application.student.model.StudentHistoryRes;
 import com.green.member.application.student.model.StudentMajorReq;
 import com.green.member.application.student.model.StudentProfileRes;
@@ -210,5 +211,29 @@ public class StudentService {
                 log.warn("기존 파일 삭제 실패: {}", e.getMessage());
             }
         }
+    }
+    // 학생 전공 변경 신청 목록 조회
+    @Transactional(readOnly = true)
+    public List<MajorRequestRes> findMajorRequests(Long memberCode){
+        if (!studentRepository.existsById(memberCode)) {
+            throw new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND);
+        }
+        List<MajorRequest> requests =
+               majorRequestRepository.findByStudent_MemberCodeOrderByCreatedAtDesc(memberCode);
+        return requests.stream()
+                .map( h -> {
+                    String majorName = majorCacheRepository.findById(h.getTargetMajorId())
+                            .map(MajorCache::getName)
+                            .orElse(null);
+                    MajorRequestRes res = new MajorRequestRes();
+                    res.setRequestId(h.getRequestId());
+                    res.setType(h.getType());
+                    res.setTargetMajorName(majorName);
+                    res.setStatus(h.getStatus());
+                    res.setCreatedAt(h.getCreatedAt());
+                    return res;
+                })
+                .toList()
+                ;
     }
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -192,4 +192,23 @@ public class StudentService {
             }
         }
     }
+
+    @Transactional
+    public void deleteMajorRequest(Long requestId, Long memberCode){
+        MajorRequest request = majorRequestRepository.findByRequestIdAndStudent_MemberCode(requestId, memberCode)
+                .orElseThrow(() -> new BusinessException(RequestErrorCode.NOT_MAJOR_REQUEST)); // requestId와 memberCode 일치
+        if (request.getStatus() != EnumApprovalStatus.PENDING) { // 대기 상태일때만 취소 가능
+            throw new BusinessException(RequestErrorCode.NOT_CANCELLABLE);
+        }
+        // 신청 취소
+        request.cancel();
+        // 첨부파일 있었다면 삭제
+        if (request.getFile() != null) {
+            try {
+                myFileUtil.deleteFile(String.format("member/major/request/%s/%s", memberCode, request.getFile()));
+            } catch (Exception e) {
+                log.warn("기존 파일 삭제 실패: {}", e.getMessage());
+            }
+        }
+    }
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -28,8 +28,17 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Slf4j
@@ -163,6 +172,7 @@ public class StudentService {
                 .targetMajorId(req.getTargetMajorId())
                 .reason(req.getReason())
                 .file(savedFileName)
+                .originalFileName(file != null ? file.getOriginalFilename() : null)
                 .gpa(BigDecimal.ZERO)
                 .build();
         MajorRequest newRequest = majorRequestRepository.save(request);
@@ -191,7 +201,7 @@ public class StudentService {
             }
         }
     }
-
+    // 내 전공 변경 신청 취소
     @Transactional
     public void deleteMajorRequest(Long requestId, Long memberCode){
         MajorRequest request = majorRequestRepository.findByRequestIdAndStudent_MemberCode(requestId, memberCode)
@@ -249,9 +259,39 @@ public class StudentService {
                 .gpa(request.getGpa())
                 .reason(request.getReason())
                 .file(request.getFile())
+                .originalFileName(request.getOriginalFileName())
                 .approveReason(request.getApproveReason())
                 .rejectReason(request.getRejectReason())
                 .createdAt(request.getCreatedAt())
                 .build();
+    }
+
+    // 학생 전공 변경 신청서 파일 다운로드
+    public ResponseEntity<Resource> findMajorRequestFile(Long requestId, Long memberCode) {
+        MajorRequest request = majorRequestRepository.findByRequestIdAndStudent_MemberCode(requestId, memberCode)
+                .orElseThrow(() -> new BusinessException(RequestErrorCode.NOT_MAJOR_REQUEST));
+
+        if (request.getFile() == null) {
+            throw new BusinessException(RequestErrorCode.FILE_NOT_FOUND);
+        }
+
+        String filePath = String.format("member/major/request/%s/%s", memberCode, request.getFile());
+
+        File file = new File(myFileUtil.fileUploadPath, filePath);
+        Resource resource = new FileSystemResource(file);
+
+        if (!resource.exists()) {
+            throw new BusinessException(RequestErrorCode.FILE_NOT_FOUND);
+        }
+
+        String downloadName = request.getOriginalFileName() != null
+                ? request.getOriginalFileName()
+                : request.getFile();
+        String encodedName = URLEncoder.encode(downloadName, StandardCharsets.UTF_8).replace("+", "%20");
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''" + encodedName)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(resource);
     }
 }

--- a/member-service/src/main/java/com/green/member/application/student/model/MajorRequestDetailRes.java
+++ b/member-service/src/main/java/com/green/member/application/student/model/MajorRequestDetailRes.java
@@ -1,0 +1,24 @@
+package com.green.member.application.student.model;
+
+import com.green.common.enumcode.EnumApprovalStatus;
+import com.green.member.enumcode.EnumMajorRequestType;
+import lombok.Data;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@ToString
+public class MajorRequestDetailRes {
+    Long requestId;
+    EnumMajorRequestType type;
+    Long targetMajorName;
+    EnumApprovalStatus status;
+    LocalDateTime createdAt;
+    BigDecimal gpa;
+    String reason;
+    String file;
+    String approveReason;
+    String rejectReason;
+}

--- a/member-service/src/main/java/com/green/member/application/student/model/MajorRequestDetailRes.java
+++ b/member-service/src/main/java/com/green/member/application/student/model/MajorRequestDetailRes.java
@@ -2,6 +2,7 @@ package com.green.member.application.student.model;
 
 import com.green.common.enumcode.EnumApprovalStatus;
 import com.green.member.enumcode.EnumMajorRequestType;
+import lombok.Builder;
 import lombok.Data;
 import lombok.ToString;
 
@@ -10,10 +11,11 @@ import java.time.LocalDateTime;
 
 @Data
 @ToString
+@Builder
 public class MajorRequestDetailRes {
     Long requestId;
     EnumMajorRequestType type;
-    Long targetMajorName;
+    String targetMajorName;
     EnumApprovalStatus status;
     LocalDateTime createdAt;
     BigDecimal gpa;

--- a/member-service/src/main/java/com/green/member/application/student/model/MajorRequestDetailRes.java
+++ b/member-service/src/main/java/com/green/member/application/student/model/MajorRequestDetailRes.java
@@ -21,6 +21,7 @@ public class MajorRequestDetailRes {
     BigDecimal gpa;
     String reason;
     String file;
+    String originalFileName;
     String approveReason;
     String rejectReason;
 }

--- a/member-service/src/main/java/com/green/member/application/student/model/MajorRequestRes.java
+++ b/member-service/src/main/java/com/green/member/application/student/model/MajorRequestRes.java
@@ -1,0 +1,18 @@
+package com.green.member.application.student.model;
+
+import com.green.common.enumcode.EnumApprovalStatus;
+import com.green.member.enumcode.EnumMajorRequestType;
+import lombok.Data;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Data
+@ToString
+public class MajorRequestRes {
+    Long requestId;
+    EnumMajorRequestType type;
+    String targetMajorName;
+    EnumApprovalStatus status;
+    LocalDateTime createdAt;
+}

--- a/member-service/src/main/java/com/green/member/application/student/model/StudentMajorReq.java
+++ b/member-service/src/main/java/com/green/member/application/student/model/StudentMajorReq.java
@@ -1,0 +1,14 @@
+package com.green.member.application.student.model;
+
+import com.green.member.enumcode.EnumMajorRequestType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class StudentMajorReq {
+    @NotNull
+    private EnumMajorRequestType type;
+    @NotNull
+    private Long targetMajorId;
+    private String reason;
+}

--- a/member-service/src/main/java/com/green/member/entity/student/MajorRequest.java
+++ b/member-service/src/main/java/com/green/member/entity/student/MajorRequest.java
@@ -55,11 +55,7 @@ public class MajorRequest extends CreatedUpdatedAt {
     @Column(name = "updator_code")
     private Long updatorCode;
 
-    public void setFile(String file){
-        this.file = file;
-    }
-
-    public void updateGpa(BigDecimal gpa) {
-        this.gpa = gpa;
-    }
+    public void setFile(String file){ this.file = file; }
+    public void updateGpa(BigDecimal gpa) { this.gpa = gpa; }
+    public void cancel() {this.status = EnumApprovalStatus.CANCELLED;}
 }

--- a/member-service/src/main/java/com/green/member/entity/student/MajorRequest.java
+++ b/member-service/src/main/java/com/green/member/entity/student/MajorRequest.java
@@ -54,4 +54,12 @@ public class MajorRequest extends CreatedUpdatedAt {
 
     @Column(name = "updator_code")
     private Long updatorCode;
+
+    public void setFile(String file){
+        this.file = file;
+    }
+
+    public void updateGpa(BigDecimal gpa) {
+        this.gpa = gpa;
+    }
 }

--- a/member-service/src/main/java/com/green/member/entity/student/MajorRequest.java
+++ b/member-service/src/main/java/com/green/member/entity/student/MajorRequest.java
@@ -38,6 +38,9 @@ public class MajorRequest extends CreatedUpdatedAt {
     @Column(name = "file")
     private String file;
 
+    @Column(name = "original_file_name")
+    private String originalFileName;
+
     @Column(name = "gpa", nullable = false)
     @Digits(integer = 1, fraction = 2)
     private BigDecimal gpa;

--- a/member-service/src/main/java/com/green/member/enumcode/EnumMajorRequestType.java
+++ b/member-service/src/main/java/com/green/member/enumcode/EnumMajorRequestType.java
@@ -1,19 +1,28 @@
 package com.green.member.enumcode;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.green.common.enumcode.AbstractEnumCodeConverter;
+import com.green.common.enumcode.EnumConvertUtils;
 import com.green.common.enumcode.EnumMapperType;
 import jakarta.persistence.Converter;
 import lombok.*;
+
 @Getter
 @RequiredArgsConstructor
 public enum EnumMajorRequestType implements EnumMapperType {
     DOUBLE("DOUBLE", "복수전공"),
-    TRANSFER("MAJOR_TRANSFER", "전과");
+    TRANSFER("TRANSFER", "전과");
 
     private final String code;
     private final String value;
+
+    @JsonCreator
+    public static EnumMajorRequestType fromCode(String code) {
+        return EnumConvertUtils.ofCode(EnumMajorRequestType.class, code);
+    }
 
     @Converter(autoApply = true)
     public static class CodeConverter extends AbstractEnumCodeConverter<EnumMajorRequestType> {
         public CodeConverter() { super(EnumMajorRequestType.class, false); }
     }
-    }
+}

--- a/member-service/src/main/java/com/green/member/enumcode/EnumMajorRequestType.java
+++ b/member-service/src/main/java/com/green/member/enumcode/EnumMajorRequestType.java
@@ -7,8 +7,7 @@ import lombok.*;
 @RequiredArgsConstructor
 public enum EnumMajorRequestType implements EnumMapperType {
     DOUBLE("DOUBLE", "복수전공"),
-    MINOR("MINOR", "부전공"),
-    MAJOR_TRANSFER("MAJOR_TRANSFER", "전과");
+    TRANSFER("MAJOR_TRANSFER", "전과");
 
     private final String code;
     private final String value;

--- a/member-service/src/main/java/com/green/member/exception/MemberErrorCode.java
+++ b/member-service/src/main/java/com/green/member/exception/MemberErrorCode.java
@@ -18,8 +18,6 @@ public enum MemberErrorCode implements ErrorCode {
     , ALREADY_RETIRED("M008", "이미 퇴사한 회원입니다.", HttpStatus.BAD_REQUEST)
     , ALREADY_DISMISSED("M009", "이미 퇴임한 교수입니다.", HttpStatus.BAD_REQUEST)
     , ALREADY_TERMINATED("M010", "퇴학 또는 자퇴 처리된 학생입니다.", HttpStatus.BAD_REQUEST)
-    , FILE_TOO_LARGE("M011", "파일 크기는 5MB 이하여야 합니다.", HttpStatus.BAD_REQUEST)
-    , INVALID_FILE_TYPE("M012", "서류는 PDF 파일만 업로드 가능합니다.", HttpStatus.BAD_REQUEST)
     ;
     private final String code;
     private final String message;

--- a/member-service/src/main/java/com/green/member/exception/MemberErrorCode.java
+++ b/member-service/src/main/java/com/green/member/exception/MemberErrorCode.java
@@ -18,6 +18,8 @@ public enum MemberErrorCode implements ErrorCode {
     , ALREADY_RETIRED("M008", "이미 퇴사한 회원입니다.", HttpStatus.BAD_REQUEST)
     , ALREADY_DISMISSED("M009", "이미 퇴임한 교수입니다.", HttpStatus.BAD_REQUEST)
     , ALREADY_TERMINATED("M010", "퇴학 또는 자퇴 처리된 학생입니다.", HttpStatus.BAD_REQUEST)
+    , FILE_TOO_LARGE("M011", "파일 크기는 5MB 이하여야 합니다.", HttpStatus.BAD_REQUEST)
+    , INVALID_FILE_TYPE("M012", "서류는 PDF 파일만 업로드 가능합니다.", HttpStatus.BAD_REQUEST)
     ;
     private final String code;
     private final String message;

--- a/member-service/src/main/java/com/green/member/exception/RequestErrorCode.java
+++ b/member-service/src/main/java/com/green/member/exception/RequestErrorCode.java
@@ -14,6 +14,7 @@ public enum RequestErrorCode implements ErrorCode {
     , ALREADY_PENDING_REQUEST("R004", "이미 처리 중인 신청이 있습니다.", HttpStatus.CONFLICT)
     , NOT_MAJOR_REQUEST("R005", "존재하지 않는 신청서입니다.", HttpStatus.NOT_FOUND)
     , NOT_CANCELLABLE("R006", "취소할 수 없는 신청입니다.", HttpStatus.BAD_REQUEST)
+    , FILE_NOT_FOUND("R007", "첨부 파일이 존재하지 않습니다.", HttpStatus.NOT_FOUND)
     ;
     private final String code;
     private final String message;

--- a/member-service/src/main/java/com/green/member/exception/RequestErrorCode.java
+++ b/member-service/src/main/java/com/green/member/exception/RequestErrorCode.java
@@ -12,6 +12,8 @@ public enum RequestErrorCode implements ErrorCode {
     , INVALID_FILE_TYPE("R002", "서류는 PDF 파일만 업로드 가능합니다.", HttpStatus.BAD_REQUEST)
     , ALREADY_IN_MAJOR("R003", "이미 소속된 학과입니다.", HttpStatus.BAD_REQUEST)
     , ALREADY_PENDING_REQUEST("R004", "이미 처리 중인 신청이 있습니다.", HttpStatus.CONFLICT)
+    , NOT_MAJOR_REQUEST("R005", "존재하지 않는 신청서입니다.", HttpStatus.NOT_FOUND)
+    , NOT_CANCELLABLE("R006", "취소할 수 없는 신청입니다.", HttpStatus.BAD_REQUEST)
     ;
     private final String code;
     private final String message;

--- a/member-service/src/main/java/com/green/member/exception/RequestErrorCode.java
+++ b/member-service/src/main/java/com/green/member/exception/RequestErrorCode.java
@@ -1,0 +1,19 @@
+package com.green.member.exception;
+
+import com.green.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RequestErrorCode implements ErrorCode {
+    FILE_TOO_LARGE("R001", "파일 크기는 5MB 이하여야 합니다.", HttpStatus.BAD_REQUEST)
+    , INVALID_FILE_TYPE("R002", "서류는 PDF 파일만 업로드 가능합니다.", HttpStatus.BAD_REQUEST)
+    , ALREADY_IN_MAJOR("R003", "이미 소속된 학과입니다.", HttpStatus.BAD_REQUEST)
+    , ALREADY_PENDING_REQUEST("R004", "이미 처리 중인 신청이 있습니다.", HttpStatus.CONFLICT)
+    ;
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/member-service/src/main/java/com/green/member/kafka/StudentConsumer.java
+++ b/member-service/src/main/java/com/green/member/kafka/StudentConsumer.java
@@ -1,0 +1,35 @@
+package com.green.member.kafka;
+
+import com.green.common.kafka.member.GpaResponseEvent;
+import com.green.common.kafka.member.MemberTopic;
+import com.green.member.application.student.MajorRequestRepository;
+import com.green.member.entity.student.MajorRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StudentConsumer {
+    private final MajorRequestRepository majorRequestRepository;
+
+    @Transactional
+    @KafkaListener(topics = MemberTopic.GPA_RESPONSE, groupId = "member-service-group")
+    public void consumeGpaResponse(GpaResponseEvent event) {
+        log.info("GPA 응답 수신 - requestId: {}, gpa: {}", event.getRequestId(), event.getGpa());
+        try {
+            MajorRequest request = majorRequestRepository.findById(event.getRequestId())
+                    .orElse(null);
+            if (request == null) {
+                log.warn("GPA 응답 대상 신청 없음 - requestId: {}", event.getRequestId());
+                return;
+            }
+            request.updateGpa(event.getGpa());
+        } catch (Exception e) {
+            log.error("GPA 업데이트 실패 - requestId: {}, error: {}", event.getRequestId(), e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈 #173 

## 관련 기능
FR-MEMB-22 | 회원 | 전공 변경 신청
FR-MEMB-21 FR-MEMB-23 | 회원 | 내 전공 변경 신청 목록 조회
회원 | 내 전공 변경 신청 상세 조회
회원 | 전공 변경 신청 취소

## 작업내용
### 전공 변경 신청
  1. 전공 변경 신청 기간 체크
  2. 동일 type PENDING 중복 신청 방지
  3. 신청 학과 존재 여부 및 현재 소속 학과 동일 여부 검증
  4. 첨부 파일 검증 (PDF, 5MB 이하)
  5. MajorRequest 저장 (gpa=0 임시값)
  6. GPA 조회 요청 이벤트 Outbox 발행 → 성적 도메인 작업 완료 후 연결 예정
### 신청 취소 (deleteMajorRequest)
  - 소프트 딜리트 — status를 CANCELLED로 변경
  - PENDING 상태인 경우에만 취소 가능
  - 첨부파일 존재 시 서버에서 삭제
### 내 신청서 목록 조회
### 내 신청서 상세 페이지 조회
  - 첨부 서류 다운로드
    - 본인 신청 파일만 접근 가능
    - Content-Disposition 헤더로 원본 파일명 다운로드
    - 한글 파일명 URL 인코딩 처리 (filename*=UTF-8''...)