### PR TITLE
feat(common) 파일 다운로드 로직 분리 / feat(member) 전공 변경 신청서 파일 다운로드 기능 정리 (#173)

### DIFF
--- a/common/src/main/java/com/green/common/file/FileService.java
+++ b/common/src/main/java/com/green/common/file/FileService.java
@@ -12,8 +12,14 @@ import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
 import java.io.File;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 @Slf4j
@@ -78,6 +84,21 @@ public class FileService {
         //filePath: 최상위 폴더 기준 상대 경로
         File file = new File(fileUtil.getFileUploadPath(), filePath);
         return new FileSystemResource(file);
+    }
+
+    // filePath 경로의 파일을 Content-Disposition 다운로드 응답으로 반환
+    // originalFileName이 있으면 그 이름으로, 없으면 저장 파일명(UUID)으로 다운로드
+    public ResponseEntity<Resource> buildDownloadResponse(String filePath, String originalFileName) {
+        Resource resource = getResource(filePath);
+        if (!resource.exists()) {
+            throw new BusinessException(FileErrorCode.FILE_NOT_FOUND);
+        }
+        String downloadName = originalFileName != null ? originalFileName : resource.getFilename();
+        String encodedName = URLEncoder.encode(downloadName, StandardCharsets.UTF_8).replace("+", "%20");
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''" + encodedName)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(resource);
     }
 
     // 지정한 경로의 파일을 삭제

--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -21,6 +21,7 @@ import com.green.member.application.student.model.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -289,6 +290,11 @@ public class AdminController {
                 .message("전공 변경 신청 상세 조회")
                 .data(res)
                 .build();
+    }
+    // 전공 변경 신청서 파일 다운로드
+    @GetMapping("/requests/major/{requestId}/file")
+    public ResponseEntity<Resource> downloadMajorRequestFile(@PathVariable Long requestId) {
+        return adminService.findMajorRequestFile(requestId);
     }
     // 전공 변경 신청 처리 (승인/반려)
     @PatchMapping("/requests/major/{requestId}")

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -4,6 +4,7 @@ import com.green.common.constants.EventType;
 import com.green.common.constants.UpdateType;
 import com.green.common.enumcode.*;
 import com.green.common.exception.CommonErrorCode;
+import com.green.common.exception.FileErrorCode;
 import com.green.member.application.major.model.AdminMajorRequestDetailRes;
 import com.green.member.application.major.model.AdminMajorRequestProcessReq;
 import com.green.member.application.major.model.AdminMajorRequestDetailDto;
@@ -46,6 +47,8 @@ import com.green.member.entity.student.StudentMajor;
 import com.green.member.enumcode.EnumAdminStatus;
 import com.green.member.enumcode.EnumMajorRequestType;
 import com.green.member.enumcode.EnumProfessorPosition;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -675,7 +678,6 @@ public class AdminService {
         // 이미지 검증 후 저장 (JPG, JPEG, PNG만 허용)
         return fileService.save(pic, "member/" + memberCode, FileService.ALLOWED_IMAGE_EXTENSIONS);
     }
-
     // 관리자 상태 변경 이력 조회
     @Transactional(readOnly = true)
     public List<AdminHistoryRes> findStatusHistory(Long memberCode){
@@ -722,7 +724,6 @@ public class AdminService {
                 .reason(detail.getReason())
                 .file(detail.getFile())
                 .originalFileName(detail.getOriginalFileName())
-                .approveReason(detail.getApproveReason())
                 .rejectReason(detail.getRejectReason())
                 .updaterName(detail.getUpdaterName())
                 .academicYear(detail.getAcademicYear())
@@ -730,6 +731,7 @@ public class AdminService {
                 .currentMajorName(detail.getCurrentMajorName())
                 .currentMinorName(detail.getCurrentMinorName())
                 .createdAt(detail.getCreatedAt())
+                .updatedAt(detail.getUpdatedAt())
                 .build();
     }
 
@@ -747,10 +749,7 @@ public class AdminService {
             throw new BusinessException(RequestErrorCode.NOT_PROCESSABLE);
         }
         if (req.getStatus() == EnumApprovalStatus.APPROVED) {
-            if (req.getApproveReason() == null || req.getApproveReason().isBlank()) {
-                throw new BusinessException(CommonErrorCode.INVALID_INPUT_VALUE);
-            }
-            request.approve(req.getApproveReason(), updaterCode);
+            request.approve(updaterCode);
 
             Long studentCode = request.getStudent().getMemberCode();
             Long targetMajorId = request.getTargetMajorId();
@@ -809,4 +808,18 @@ public class AdminService {
             request.reject(req.getRejectReason(), updaterCode);
         }
     }
+
+    // 전공 변경 신청서 파일 다운로드 (관리자 — 소유권 제한 없음)
+    @Transactional(readOnly = true)
+    public ResponseEntity<Resource> findMajorRequestFile(Long requestId) {
+        MajorRequest request = majorRequestRepository.findById(requestId)
+                .orElseThrow(() -> new BusinessException(RequestErrorCode.NOT_MAJOR_REQUEST));
+        if (request.getFile() == null) {
+            throw new BusinessException(FileErrorCode.FILE_NOT_FOUND);
+        }
+        Long studentCode = request.getStudent().getMemberCode();
+        String filePath = String.format("request/major/%s/%s", studentCode, request.getFile());
+        return fileService.buildDownloadResponse(filePath, request.getOriginalFileName());
+    }
+
 }

--- a/member-service/src/main/java/com/green/member/application/major/MajorRequestRepository.java
+++ b/member-service/src/main/java/com/green/member/application/major/MajorRequestRepository.java
@@ -59,10 +59,10 @@ public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long
                    mr.academic_year       AS academicYear,
                    mr.semester            AS semester,
                    mr.original_file_name  AS originalFileName,
-                   mr.approve_reason      AS approveReason,
                    mr.reject_reason       AS rejectReason,
                    um.name                AS updaterName,
-                   mr.created_at          AS createdAt
+                   mr.created_at          AS createdAt,
+                   mr.updated_at          AS updatedAt
             FROM major_request mr
             JOIN member m       ON m.member_code  = mr.student_code
             JOIN major_cache mc ON mc.major_id  = mr.target_major_id
@@ -101,7 +101,6 @@ public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long
                    mr.reason              AS reason,
                    mr.file                AS file,
                    mr.original_file_name  AS originalFileName,
-                   mr.approve_reason      AS approveReason,
                    mr.reject_reason       AS rejectReason,
                    mr.academic_year       AS academicYear,
                    mr.semester            AS semester,

--- a/member-service/src/main/java/com/green/member/application/major/MajorRequestRepository.java
+++ b/member-service/src/main/java/com/green/member/application/major/MajorRequestRepository.java
@@ -22,16 +22,20 @@ public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long
     // 관리자 전공 변경 신청 목록 조회
     @Query(value = """
             SELECT mr.request_id       AS requestId,
-                   m.member_code       AS memberCode,
-                   m.name              AS studentName,
+                   ms.member_code       AS memberCode,
+                   ms.name              AS studentName,
+                   ma.name              AS updaterName,
                    mc.name             AS targetMajorName,
                    mc_current.name     AS currentMajorName,
                    mc_minor.name       AS currentMinorName,
                    mr.type             AS type,
                    mr.status           AS status,
+                   mr.academic_year    AS academicYear,
+                   mr.semester         AS semsester,
                    mr.created_at       AS createdAt
             FROM major_request mr
-            JOIN member m      ON m.member_code = mr.student_code
+            JOIN member ms      ON ms.member_code = mr.student_code
+            LEFT JOIN member ma      on ma.member_code = mr.updater_code
             JOIN major_cache mc ON mc.major_id  = mr.target_major_id
             JOIN major_cache mc_current ON mc_current.major_id = mr.current_major_id
             LEFT JOIN major_cache mc_minor ON mc_minor.major_id = mr.current_minor_id

--- a/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestDetailDto.java
+++ b/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestDetailDto.java
@@ -16,10 +16,10 @@ public interface AdminMajorRequestDetailDto {
     String getReason();
     String getFile();
     String getOriginalFileName();
-    String getApproveReason();
     String getRejectReason();
     String getUpdaterName();
     Integer getAcademicYear();
     Integer getSemester();
     LocalDateTime getCreatedAt();
+    LocalDateTime getUpdatedAt();
 }

--- a/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestDetailRes.java
+++ b/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestDetailRes.java
@@ -19,7 +19,6 @@ public class AdminMajorRequestDetailRes {
     String reason;
     String file;
     String originalFileName;
-    String approveReason;
     String rejectReason;
     String updaterName;
     Integer academicYear;
@@ -27,4 +26,5 @@ public class AdminMajorRequestDetailRes {
     String currentMajorName;
     String currentMinorName;
     LocalDateTime createdAt;
+    LocalDateTime updatedAt;
 }

--- a/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestListRes.java
+++ b/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestListRes.java
@@ -9,6 +9,10 @@ public interface AdminMajorRequestListRes {
     String getTargetMajorName();
     String getCurrentMajorName();
     String getCurrentMinorName();
+    LocalDateTime getCreatedDate();
+    String getUpdaterName();
+    Integer getAcademicYear();
+    Integer getSemester();
     String getType();
     String getStatus();
     LocalDateTime getCreatedAt();

--- a/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestProcessReq.java
+++ b/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestProcessReq.java
@@ -8,6 +8,5 @@ import lombok.Data;
 public class AdminMajorRequestProcessReq {
     @NotNull
     private EnumApprovalStatus status; // APPROVED 또는 REJECTED만 허용
-    private String approveReason;
     private String rejectReason;
 }

--- a/member-service/src/main/java/com/green/member/application/major/model/StudentMajorRequestDetailRes.java
+++ b/member-service/src/main/java/com/green/member/application/major/model/StudentMajorRequestDetailRes.java
@@ -12,7 +12,6 @@ public interface StudentMajorRequestDetailRes {
     String getReason();
     String getFile();
     String getOriginalFileName();
-    String getApproveReason();
     String getRejectReason();
     Integer getAcademicYear();
     Integer getSemester();

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -32,13 +32,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import org.springframework.core.io.Resource;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import java.math.BigDecimal;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -237,34 +233,15 @@ public class StudentService {
 
     // 내 전공 변경 신청서 파일 다운로드
     public ResponseEntity<Resource> findMajorRequestFile(Long requestId, Long memberCode) {
-        // 신청서 소유권 확인: requestId + memberCode 조합으로 타인의 파일 접근 차단
+        // requestId + memberCode 조합으로 타인의 파일 접근 차단
         MajorRequest request = majorRequestRepository.findByRequestIdAndStudent_MemberCode(requestId, memberCode)
                 .orElseThrow(() -> new BusinessException(RequestErrorCode.NOT_MAJOR_REQUEST));
-
         if (request.getFile() == null) {
             throw new BusinessException(FileErrorCode.FILE_NOT_FOUND);
         }
-
-        // DB에 저장된 UUID 기반 파일명으로 경로 구성 (클라이언트 입력값 미사용 → path traversal 불가)
+        // DB의 UUID 파일명으로 경로 구성 (클라이언트 입력값 미사용 → path traversal 불가)
         String filePath = String.format("request/major/%s/%s", memberCode, request.getFile());
-        Resource resource = fileService.getResource(filePath);
-
-        if (!resource.exists()) {
-            throw new BusinessException(FileErrorCode.FILE_NOT_FOUND);
-        }
-
-        // 다운로드 파일명: 저장 시 살균된 원본 파일명 우선, 없으면 UUID 파일명 사용
-        String downloadName = request.getOriginalFileName() != null
-                ? request.getOriginalFileName()
-                : request.getFile();
-        // RFC 5987 인코딩으로 한글/특수문자 파일명 안전 처리
-        String encodedName = URLEncoder.encode(downloadName, StandardCharsets.UTF_8).replace("+", "%20");
-
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''" + encodedName)
-                // 브라우저가 파일을 직접 실행하지 않도록 OCTET_STREAM으로 강제 다운로드
-                .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                .body(resource);
+        return fileService.buildDownloadResponse(filePath, request.getOriginalFileName());
     }
 
 }

--- a/member-service/src/main/java/com/green/member/entity/student/MajorRequest.java
+++ b/member-service/src/main/java/com/green/member/entity/student/MajorRequest.java
@@ -61,9 +61,6 @@ public class MajorRequest extends CreatedUpdatedAt {
     @Builder.Default
     private EnumApprovalStatus status = EnumApprovalStatus.PENDING;
 
-    @Column(name = "approve_reason")
-    private String approveReason;
-
     @Column(name = "reject_reason")
     private String rejectReason;
 
@@ -75,9 +72,8 @@ public class MajorRequest extends CreatedUpdatedAt {
     public void cancel() { this.status = EnumApprovalStatus.CANCELLED; }
 
     // 신청서 승인
-    public void approve(String approveReason, Long updaterCode) {
+    public void approve(Long updaterCode) {
         this.status = EnumApprovalStatus.APPROVED;
-        this.approveReason = approveReason;
         this.updaterCode = updaterCode;
     }
     // 신청서 반려


### PR DESCRIPTION
## 관련 이슈 #173 

## 관련 기능
FR-MEMB-24 | 관리자 | 회원 | 전공 변경 신청 조회
FR-MEMB-25 | 관리자 | 회원 | 전공 변경 신청 처리

## 작업내용
  1. 관리자 전공 변경 신청서 파일 다운로드 추가
  - 학생은 본인 신청서만 다운로드 가능, 관리자는 소유권 제한 없이 모든 신청서 파일 다운로드 가능

  2. 파일 다운로드 공통 로직 추출
  - FileService.buildDownloadResponse(filePath, originalFileName) 메서드 추가
  - 기존 StudentService, 신규 AdminService 모두 이 메서드를 사용하도록 변경
  - 향후 휴학신청서 등 다른 파일 다운로드도 동일한 메서드 재사용 가능

  3. 전공 변경 신청서 approveReason 컬럼 제거
  - 승인 시 사유 필수 입력 요건 제거 → 승인 처리 오류 수정