### PR TITLE
feat(member) 전공 변경 신청 조회 처리시 로그인 유저의 상태값 확인 예외처리 (#173)

### DIFF
--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -276,7 +276,8 @@ public class AdminController {
     // 전공 변경 신청 목록 조회
     @GetMapping("/requests/major")
     public ResultResponse<?> findAllMajorRequests() {
-        List<AdminMajorRequestListRes> res = adminService.findMajorRequests();
+        MemberDto loginMember = MemberContext.get();
+        List<AdminMajorRequestListRes> res = adminService.findMajorRequests( loginMember.memberCode() );
         return ResultResponse.builder()
                 .message("전공 변경 신청 목록 조회 완료")
                 .data(res)
@@ -285,7 +286,8 @@ public class AdminController {
     // 전공 변경 신청 상세 조회
     @GetMapping("/requests/major/{requestId}")
     public ResultResponse<?> findMajorRequestDetail(@PathVariable Long requestId) {
-        AdminMajorRequestDetailRes res = adminService.findMajorRequestDetail(requestId);
+        MemberDto loginMember = MemberContext.get();
+        AdminMajorRequestDetailRes res = adminService.findMajorRequestDetail( requestId, loginMember.memberCode() );
         return ResultResponse.builder()
                 .message("전공 변경 신청 상세 조회")
                 .data(res)
@@ -294,13 +296,14 @@ public class AdminController {
     // 전공 변경 신청서 파일 다운로드
     @GetMapping("/requests/major/{requestId}/file")
     public ResponseEntity<Resource> downloadMajorRequestFile(@PathVariable Long requestId) {
-        return adminService.findMajorRequestFile(requestId);
+        MemberDto loginMember = MemberContext.get();
+        return adminService.findMajorRequestFile( requestId, loginMember.memberCode() );
     }
     // 전공 변경 신청 처리 (승인/반려)
     @PatchMapping("/requests/major/{requestId}")
     public ResultResponse<?> updateMajorRequest(@PathVariable Long requestId, @RequestBody @Valid AdminMajorRequestProcessReq req) {
         MemberDto loginMember = MemberContext.get();
-        adminService.processMajorRequest( requestId , req, loginMember.memberCode());
+        adminService.processMajorRequest( requestId , req, loginMember.memberCode() );
         return ResultResponse.builder()
                 .message("전공 변경 신청서 처리 완료")
                 .build();

--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -7,6 +7,7 @@ import com.green.member.application.admin.model.*;
 import com.green.member.application.major.model.AdminMajorRequestDetailRes;
 import com.green.member.application.major.model.AdminMajorRequestProcessReq;
 import com.green.member.application.major.model.AdminMajorRequestListRes;
+import com.green.member.application.major.model.AdminStudentMajorHistoryRes;
 import com.green.member.application.member.model.MemberCreateRes;
 import com.green.member.application.member.model.MemberProfileRes;
 import com.green.member.application.professor.ProfessorBatchService;
@@ -60,6 +61,16 @@ public class AdminController {
         List<StudentHistoryRes> res = studentService.findStudentHistory( memberCode );
         return ResultResponse.builder()
                 .message("관리자의 학생 계정 상태 변경 이력 조회")
+                .data(res)
+                .build();
+    }
+
+    @GetMapping("/students/{memberCode}/history/major")
+    public ResultResponse<?> findStudentMajorHistory(@PathVariable Long memberCode) {
+        MemberDto loginMember = MemberContext.get();
+        List<AdminStudentMajorHistoryRes> res = adminService.findStudentMajorHistory(memberCode, loginMember.memberCode());
+        return ResultResponse.builder()
+                .message("관리자의 학생 전공 변경 이력 조회")
                 .data(res)
                 .build();
     }

--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -32,7 +32,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.List;
 
-
 @Slf4j
 @RestController
 @RequiredArgsConstructor

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -703,13 +703,21 @@ public class AdminService {
 
     // 전공 변경 신청 목록 전체 조회
     @Transactional(readOnly = true)
-    public List<AdminMajorRequestListRes> findMajorRequests() {
+    public List<AdminMajorRequestListRes> findMajorRequests( Long memberCode ) {
+        Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
+        if(admin.getStatus() != EnumAdminStatus.EMPLOYMENT ){
+            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
+        }
         return majorRequestRepository.findAllByFilter();
     }
 
     // 전공 변경 신청 상세 조회 (신청 당시 전공 정보는 MajorRequest에 스냅샷으로 저장된 값 사용)
     @Transactional(readOnly = true)
-    public AdminMajorRequestDetailRes findMajorRequestDetail(Long requestId) {
+    public AdminMajorRequestDetailRes findMajorRequestDetail( Long requestId, Long memberCode ) {
+        Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
+        if(admin.getStatus() != EnumAdminStatus.EMPLOYMENT ){
+            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
+        }
         AdminMajorRequestDetailDto detail = majorRequestRepository.findDetailByRequestId(requestId)
                 .orElseThrow(() -> new BusinessException(RequestErrorCode.NOT_MAJOR_REQUEST));
 
@@ -738,6 +746,11 @@ public class AdminService {
     // 전공 변경 신청 처리
     @Transactional
     public void processMajorRequest(Long requestId, AdminMajorRequestProcessReq req, Long updaterCode) {
+        Admin admin = adminRepository.findById(updaterCode)
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
+        if (admin.getStatus() != EnumAdminStatus.EMPLOYMENT) {
+            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
+        }
         // APPROVED, REJECTED 외 상태는 처리 불가
         if (req.getStatus() != EnumApprovalStatus.APPROVED && req.getStatus() != EnumApprovalStatus.REJECTED) {
             throw new BusinessException(CommonErrorCode.INVALID_INPUT_VALUE);
@@ -811,7 +824,11 @@ public class AdminService {
 
     // 전공 변경 신청서 파일 다운로드 (관리자 — 소유권 제한 없음)
     @Transactional(readOnly = true)
-    public ResponseEntity<Resource> findMajorRequestFile(Long requestId) {
+    public ResponseEntity<Resource> findMajorRequestFile( Long requestId, Long memberCode) {
+        Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
+        if(admin.getStatus() != EnumAdminStatus.EMPLOYMENT ){
+            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
+        }
         MajorRequest request = majorRequestRepository.findById(requestId)
                 .orElseThrow(() -> new BusinessException(RequestErrorCode.NOT_MAJOR_REQUEST));
         if (request.getFile() == null) {

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -9,6 +9,7 @@ import com.green.member.application.major.model.AdminMajorRequestDetailRes;
 import com.green.member.application.major.model.AdminMajorRequestProcessReq;
 import com.green.member.application.major.model.AdminMajorRequestDetailDto;
 import com.green.member.application.major.model.AdminMajorRequestListRes;
+import com.green.member.application.major.model.AdminStudentMajorHistoryRes;
 import com.green.member.application.professor.model.ProfessorListDto;
 import com.green.member.application.major.MajorRequestRepository;
 import com.green.member.application.student.model.*;
@@ -837,6 +838,20 @@ public class AdminService {
         Long studentCode = request.getStudent().getMemberCode();
         String filePath = String.format("request/major/%s/%s", studentCode, request.getFile());
         return fileService.buildDownloadResponse(filePath, request.getOriginalFileName());
+    }
+
+    // 특정 학생의 전공 변경 이력 조회 (관리자용)
+    @Transactional(readOnly = true)
+    public List<AdminStudentMajorHistoryRes> findStudentMajorHistory(Long studentCode, Long adminCode) {
+        Admin admin = adminRepository.findById(adminCode)
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
+        if (admin.getStatus() != EnumAdminStatus.EMPLOYMENT) {
+            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
+        }
+        if (!studentRepository.existsById(studentCode)) {
+            throw new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND);
+        }
+        return majorRequestRepository.findMajorHistoryByStudentCodeForAdmin(studentCode);
     }
 
 }

--- a/member-service/src/main/java/com/green/member/application/major/MajorRequestRepository.java
+++ b/member-service/src/main/java/com/green/member/application/major/MajorRequestRepository.java
@@ -6,7 +6,6 @@ import com.green.member.application.major.model.AdminMajorRequestListRes;
 import com.green.member.application.major.model.StudentMajorRequestDetailRes;
 import com.green.member.application.major.model.StudentMajorRequestListRes;
 import com.green.member.entity.student.MajorRequest;
-import com.green.member.enumcode.EnumMajorRequestType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,8 +15,7 @@ import java.util.Optional;
 
 public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long> {
     Optional<MajorRequest> findByRequestIdAndStudent_MemberCode(Long requestId, Long memberCode);
-    boolean existsByStudent_MemberCodeAndTypeAndStatus(
-            Long memberCode, EnumMajorRequestType type, EnumApprovalStatus status);
+    boolean existsByStudent_MemberCodeAndStatus(Long memberCode, EnumApprovalStatus status);
 
     // 관리자 전공 변경 신청 목록 조회
     @Query(value = """

--- a/member-service/src/main/java/com/green/member/application/major/MajorRequestRepository.java
+++ b/member-service/src/main/java/com/green/member/application/major/MajorRequestRepository.java
@@ -3,6 +3,8 @@ package com.green.member.application.major;
 import com.green.common.enumcode.EnumApprovalStatus;
 import com.green.member.application.major.model.AdminMajorRequestDetailDto;
 import com.green.member.application.major.model.AdminMajorRequestListRes;
+import com.green.member.application.major.model.AdminStudentMajorHistoryRes;
+import com.green.member.application.major.model.StudentMajorHistoryRes;
 import com.green.member.application.major.model.StudentMajorRequestDetailRes;
 import com.green.member.application.major.model.StudentMajorRequestListRes;
 import com.green.member.entity.student.MajorRequest;
@@ -115,4 +117,48 @@ public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long
     Optional<StudentMajorRequestDetailRes> findStudentMajorRequestDetail(
             @Param("requestId")  Long requestId,
             @Param("memberCode") Long memberCode);
+
+    // 학생 전공 변경 이력 조회
+    @Query(value = """
+            SELECT mr.type                                              AS type,
+                   CASE
+                       WHEN mr.type = 'TRANSFER' THEN mc_current.name
+                       WHEN mr.type = 'MINOR'    THEN mc_minor.name
+                   END                                                 AS beforeName,
+                   mc_target.name                                      AS afterName,
+                   mr.academic_year                                    AS academicYear,
+                   mr.semester                                         AS semester,
+                   mr.updated_at                                       AS updatedAt
+            FROM major_request mr
+            JOIN major_cache mc_current ON mc_current.major_id = mr.current_major_id
+            JOIN major_cache mc_target  ON mc_target.major_id  = mr.target_major_id
+            LEFT JOIN major_cache mc_minor ON mc_minor.major_id = mr.current_minor_id
+            WHERE mr.student_code = :memberCode
+              AND mr.status = 'APPROVED'
+            ORDER BY mr.updated_at ASC
+            """, nativeQuery = true)
+    List<StudentMajorHistoryRes> findMajorHistoryByStudentCode(@Param("memberCode") Long memberCode);
+
+    // 학생 전공 변경 이력 조회 (관리자용)
+    @Query(value = """
+            SELECT mr.type                                              AS type,
+                   CASE
+                       WHEN mr.type = 'TRANSFER' THEN mc_current.name
+                       WHEN mr.type = 'MINOR'    THEN mc_minor.name
+                   END                                                 AS beforeName,
+                   mc_target.name                                      AS afterName,
+                   mr.academic_year                                    AS academicYear,
+                   mr.semester                                         AS semester,
+                   m.name                                              AS updaterName,
+                   mr.updated_at                                       AS updatedAt
+            FROM major_request mr
+            JOIN major_cache mc_current ON mc_current.major_id = mr.current_major_id
+            JOIN major_cache mc_target  ON mc_target.major_id  = mr.target_major_id
+            LEFT JOIN major_cache mc_minor ON mc_minor.major_id = mr.current_minor_id
+            LEFT JOIN member m           ON m.member_code = mr.updater_code
+            WHERE mr.student_code = :memberCode
+              AND mr.status = 'APPROVED'
+            ORDER BY mr.updated_at ASC
+            """, nativeQuery = true)
+    List<AdminStudentMajorHistoryRes> findMajorHistoryByStudentCodeForAdmin(@Param("memberCode") Long memberCode);
 }

--- a/member-service/src/main/java/com/green/member/application/major/MajorRequestRepository.java
+++ b/member-service/src/main/java/com/green/member/application/major/MajorRequestRepository.java
@@ -31,7 +31,7 @@ public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long
                    mr.type             AS type,
                    mr.status           AS status,
                    mr.academic_year    AS academicYear,
-                   mr.semester         AS semsester,
+                   mr.semester         AS semester,
                    mr.created_at       AS createdAt
             FROM major_request mr
             JOIN member ms      ON ms.member_code = mr.student_code

--- a/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestListRes.java
+++ b/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestListRes.java
@@ -9,7 +9,6 @@ public interface AdminMajorRequestListRes {
     String getTargetMajorName();
     String getCurrentMajorName();
     String getCurrentMinorName();
-    LocalDateTime getCreatedDate();
     String getUpdaterName();
     Integer getAcademicYear();
     Integer getSemester();

--- a/member-service/src/main/java/com/green/member/application/major/model/AdminStudentMajorHistoryRes.java
+++ b/member-service/src/main/java/com/green/member/application/major/model/AdminStudentMajorHistoryRes.java
@@ -1,0 +1,13 @@
+package com.green.member.application.major.model;
+
+import java.time.LocalDateTime;
+
+public interface AdminStudentMajorHistoryRes {
+    String getType();
+    String getBeforeName();
+    String getAfterName();
+    Integer getAcademicYear();
+    Integer getSemester();
+    String getUpdaterName();
+    LocalDateTime getUpdatedAt();
+}

--- a/member-service/src/main/java/com/green/member/application/major/model/StudentMajorHistoryRes.java
+++ b/member-service/src/main/java/com/green/member/application/major/model/StudentMajorHistoryRes.java
@@ -1,0 +1,12 @@
+package com.green.member.application.major.model;
+
+import java.time.LocalDateTime;
+
+public interface StudentMajorHistoryRes {
+    String getType();
+    String getBeforeName();
+    String getAfterName();
+    Integer getAcademicYear();
+    Integer getSemester();
+    LocalDateTime getUpdatedAt();
+}

--- a/member-service/src/main/java/com/green/member/application/student/StudentController.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentController.java
@@ -3,6 +3,7 @@ package com.green.member.application.student;
 import com.green.common.auth.MemberContext;
 import com.green.common.model.MemberDto;
 import com.green.common.model.ResultResponse;
+import com.green.member.application.major.model.StudentMajorHistoryRes;
 import com.green.member.application.major.model.StudentMajorRequestDetailRes;
 import com.green.member.application.major.model.StudentMajorRequestListRes;
 import com.green.member.application.student.model.*;
@@ -77,5 +78,16 @@ public class StudentController {
     public ResponseEntity<Resource> downloadMajorRequestFile(@PathVariable Long requestId) {
         MemberDto loginMember = MemberContext.get();
         return studentService.findMajorRequestFile(requestId, loginMember.memberCode());
+    }
+
+    // 내 전공 변경 이력 조회
+    @GetMapping("/history/major")
+    public ResultResponse<?> findMajorHistory() {
+        MemberDto loginMember = MemberContext.get();
+        List<StudentMajorHistoryRes> res = studentService.findMajorHistory(loginMember.memberCode());
+        return ResultResponse.builder()
+                .message("전공 변경 이력 조회")
+                .data(res)
+                .build();
     }
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -23,6 +23,7 @@ import com.green.member.entity.student.MajorRequest;
 import com.green.member.entity.student.Student;
 import com.green.member.entity.student.StudentHistory;
 import com.green.member.entity.student.StudentMajor;
+import com.green.member.enumcode.EnumMajorRequestType;
 import com.green.member.exception.MemberErrorCode;
 import com.green.member.application.major.MajorCacheRepository;
 import com.green.member.exception.RequestErrorCode;
@@ -139,11 +140,16 @@ public class StudentService {
             throw new BusinessException(RequestErrorCode.INELIGIBLE_STUDENT_STATUS);
         }
 
+        // 편입생은 전과 신청 불가
+        if (req.getType() == EnumMajorRequestType.TRANSFER && student.getIsTransfer()) {
+            throw new BusinessException(RequestErrorCode.TRANSFER_STUDENT_CANNOT_TRANSFER);
+        }
+
         // 전공 변경 신청 기간 체크
         schedulePeriodValidator.checkMajorChange();
 
-        // 중복 신청 방지
-        if (majorRequestRepository.existsByStudent_MemberCodeAndTypeAndStatus( memberCode, req.getType(), EnumApprovalStatus.PENDING)) {
+        // 중복 신청 방지 (타입 무관하게 PENDING 신청이 하나라도 있으면 차단)
+        if (majorRequestRepository.existsByStudent_MemberCodeAndStatus(memberCode, EnumApprovalStatus.PENDING)) {
             throw new BusinessException(RequestErrorCode.ALREADY_PENDING_REQUEST);
         }
 

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -12,6 +12,7 @@ import com.green.common.kafka.member.MemberTopic;
 import com.green.member.application.OutboxService;
 import com.green.common.file.FileService;
 import com.green.member.application.major.MajorRequestRepository;
+import com.green.member.application.major.model.StudentMajorHistoryRes;
 import com.green.member.application.major.model.StudentMajorRequestDetailRes;
 import com.green.member.application.major.model.StudentMajorRequestListRes;
 import com.green.member.application.member.MemberRepository;
@@ -234,6 +235,15 @@ public class StudentService {
             throw new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND);
         }
         return majorRequestRepository.findStudentMajorRequests(memberCode);
+    }
+
+    // 내 전공 변경 이력 조회
+    @Transactional(readOnly = true)
+    public List<StudentMajorHistoryRes> findMajorHistory(Long memberCode) {
+        if (!studentRepository.existsById(memberCode)) {
+            throw new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND);
+        }
+        return majorRequestRepository.findMajorHistoryByStudentCode(memberCode);
     }
 
     // 내 전공 변경 신청서 상세 조회

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -238,6 +238,7 @@ public class StudentService {
     }
 
     // 내 전공 변경 신청서 파일 다운로드
+    @Transactional(readOnly = true)
     public ResponseEntity<Resource> findMajorRequestFile(Long requestId, Long memberCode) {
         // requestId + memberCode 조합으로 타인의 파일 접근 차단
         MajorRequest request = majorRequestRepository.findByRequestIdAndStudent_MemberCode(requestId, memberCode)

--- a/member-service/src/main/java/com/green/member/exception/MemberErrorCode.java
+++ b/member-service/src/main/java/com/green/member/exception/MemberErrorCode.java
@@ -18,6 +18,7 @@ public enum MemberErrorCode implements ErrorCode {
     , ALREADY_RETIRED("M008", "이미 퇴사한 회원입니다.", HttpStatus.BAD_REQUEST)
     , ALREADY_DISMISSED("M009", "이미 퇴임한 교수입니다.", HttpStatus.BAD_REQUEST)
     , ALREADY_TERMINATED("M010", "퇴학 또는 자퇴 처리된 학생입니다.", HttpStatus.BAD_REQUEST)
+    , ADMIN_NOT_EMPLOYED("M011", "처리 권한이 없습니다.", HttpStatus.FORBIDDEN)
     ;
     private final String code;
     private final String message;

--- a/member-service/src/main/java/com/green/member/exception/RequestErrorCode.java
+++ b/member-service/src/main/java/com/green/member/exception/RequestErrorCode.java
@@ -14,6 +14,7 @@ public enum RequestErrorCode implements ErrorCode {
     , ALREADY_IN_MAJOR("R004", "이미 소속된 학과입니다.", HttpStatus.BAD_REQUEST)
     , NOT_PROCESSABLE("R005", "이미 처리된 신청입니다.", HttpStatus.BAD_REQUEST)
     , INELIGIBLE_STUDENT_STATUS("R006", "현재 학적 상태로는 신청할 수 없습니다.", HttpStatus.BAD_REQUEST)
+    , TRANSFER_STUDENT_CANNOT_TRANSFER("R007", "편입생은 전과 신청을 할 수 없습니다.", HttpStatus.BAD_REQUEST)
     ;
     private final String code;
     private final String message;


### PR DESCRIPTION
## 관련 이슈
closes #173 

## 작업내용
  1. 비재직 관리자의 전공 변경 신청 접근 차단
  2. 학생 전공 변경 신청 중복 차단 범위 확대
  3. 편입생 전과 신청 차단
  4. 전공 변동 이력 조회 기능 추가
    - 관리자, 학생 API 개별 구현