### PR TITLE
fix(member) 회원 도메인 버그 확인 및 처리 (#215)

### DIFF
--- a/member-service/src/main/java/com/green/member/application/admin/AdminController.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminController.java
@@ -63,7 +63,7 @@ public class AdminController {
     @GetMapping("/history")
     public ResultResponse<?> findHistory(){
         MemberDto loginMember = MemberContext.get();
-        List<AdminHistoryRes> res = adminService.findStatusHistory( loginMember.memberCode() );
+        List<AdminHistoryRes> res = adminService.findStatusHistory( loginMember.memberCode(), loginMember.memberCode() );
         return ResultResponse.builder()
                 .message("관리자 상태 변경 이력 조회")
                 .data(res)
@@ -99,7 +99,8 @@ public class AdminController {
     }
     @GetMapping("/admins/{memberCode}/history")
     public ResultResponse<?> findAdminHistory(@PathVariable Long memberCode){
-        List<AdminHistoryRes> res = adminService.findStatusHistory( memberCode );
+        MemberDto loginMember = MemberContext.get();
+        List<AdminHistoryRes> res = adminService.findStatusHistory( memberCode, loginMember.memberCode() );
         return ResultResponse.builder()
                 .message("관리자의 관리자 계정 상태 변경 이력 조회")
                 .data(res)
@@ -109,7 +110,8 @@ public class AdminController {
     // 회원 상세 정보 조회
     @GetMapping("/{memberCode}")
     public ResultResponse<?> findMemberProfile(@PathVariable Long memberCode) {
-        MemberProfileRes res = adminService.getMemberProfile(memberCode);
+        MemberDto loginMember = MemberContext.get();
+        MemberProfileRes res = adminService.getMemberProfile(memberCode, loginMember.memberCode());
         return ResultResponse.builder()
                 .message("회원 프로파일 조회")
                 .data(res)
@@ -119,7 +121,8 @@ public class AdminController {
     // 학생 회원 목록 조회
     @GetMapping("/students")
     public ResultResponse<?> findStudentList(){
-        List<StudentListDto> res = adminService.findStudents();
+        MemberDto loginMember = MemberContext.get();
+        List<StudentListDto> res = adminService.findStudents(loginMember.memberCode());
         return ResultResponse.builder()
                 .message("학생 목록 조회 성공")
                 .data(res)
@@ -128,7 +131,8 @@ public class AdminController {
     // 교수 회원 목록 조회
     @GetMapping("/professors")
     public ResultResponse<?> findProfessorList(){
-        List<ProfessorListDto> res = adminService.findProfessors();
+        MemberDto loginMember = MemberContext.get();
+        List<ProfessorListDto> res = adminService.findProfessors(loginMember.memberCode());
         return ResultResponse.builder()
                 .message("교수 목록 조회 성공")
                 .data(res)
@@ -137,7 +141,8 @@ public class AdminController {
     // 관리자 회원 목록 조회
     @GetMapping("/admins")
     public ResultResponse<?> findAdminList(){
-        List<AdminListDto> res = adminService.findAdmins();
+        MemberDto loginMember = MemberContext.get();
+        List<AdminListDto> res = adminService.findAdmins(loginMember.memberCode());
         return ResultResponse.builder()
                 .message("관리자 목록 조회 성공")
                 .data(res)

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -1019,6 +1019,13 @@ public class AdminService {
             // 학생 상태 업데이트
             student.updateStatus(newStatus);
 
+            // 자퇴 승인 시 자퇴 처리일 기록
+            if (newStatus == EnumStudentStatus.QUIT) {
+                Member member = memberRepository.findById(studentCode)
+                        .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+                member.setExitDate(LocalDate.now());
+            }
+
             // StudentEvent Outbox 저장
             outboxService.saveToOutbox(
                     MemberTopic.STUDENT,

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -85,29 +85,38 @@ public class AdminService {
     private final MajorRequestRepository majorRequestRepository;
     private final StatusRequestRepository statusRequestRepository;
 
+    // 재직 중인 관리자인지 검증
+    private void validateEmployedAdmin(Long memberCode) {
+        Admin admin = adminRepository.findById(memberCode)
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
+        if (admin.getStatus() != EnumAdminStatus.EMPLOYMENT) {
+            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
+        }
+    }
+
     // 학생 목록 조회
     @Transactional(readOnly = true)
-    public List<StudentListDto> findStudents() {
+    public List<StudentListDto> findStudents(Long memberCode) {
+        validateEmployedAdmin(memberCode);
         return studentRepository.findStudentList();
     }
     // 교수 목록 조회
     @Transactional(readOnly = true)
-    public List<ProfessorListDto> findProfessors() {
+    public List<ProfessorListDto> findProfessors(Long memberCode) {
+        validateEmployedAdmin(memberCode);
         return professorRepository.findProfessorList();
     }
     // 관리자 목록 조회
     @Transactional(readOnly = true)
-    public List<AdminListDto> findAdmins() {
+    public List<AdminListDto> findAdmins(Long memberCode) {
+        validateEmployedAdmin(memberCode);
         return adminRepository.findAdminList();
     }
 
     // 대시보드: 학생/교수/관리자 계정 수 조회
     @Transactional(readOnly = true)
     public MemberCountRes getMemberCounts(Long memberCode) {
-        Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
-        if (admin.getStatus() != EnumAdminStatus.EMPLOYMENT) {
-            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
-        }
+        validateEmployedAdmin(memberCode);
         return new MemberCountRes(
                 studentRepository.count(),
                 professorRepository.count(),
@@ -181,9 +190,10 @@ public class AdminService {
         return newMember;
     }
 
-    // 학생 정보 추가
+    // 학생 계정 등록
     @Transactional
     public MemberCreateRes createStudent(StudentCreateReq req, MultipartFile pic, Long updaterCode) {
+        validateEmployedAdmin(updaterCode);
         Member member = createMember(req, pic, EnumMemberRole.STUDENT);
 
         // 학생 테이블 저장
@@ -209,7 +219,7 @@ public class AdminService {
         StudentMajor savedStudentMajor = studentMajorRepository.save(studentMajor);
 
         // 입학 이력 저장 (신규입학 / 편입학 구분)
-        String changeType = savedStudent.getIsTransfer() ? "편입학" : "신규입학";
+        String changeType = savedStudent.getIsTransfer() ? "편입학" : "신규 입학";
         studentHistoryRepository.save(StudentHistory.builder()
                 .student(savedStudent)
                 .changeType(changeType)
@@ -240,9 +250,10 @@ public class AdminService {
                 .build();
     }
 
-    // 교수 정보 추가
+    // 교수 계정 등록
     @Transactional
     public MemberCreateRes createProfessor(ProfessorCreateReq req, MultipartFile pic, Long updaterCode) {
+        validateEmployedAdmin(updaterCode);
         Member member = createMember(req, pic, EnumMemberRole.PROFESSOR);
 
         Professor newProfessor = Professor.builder()
@@ -261,7 +272,7 @@ public class AdminService {
         // 신규임용 이력 저장
         professorHistoryRepository.save(ProfessorHistory.builder()
                 .professor(savedProfessor)
-                .changeType("신규임용")
+                .changeType("신규 임용")
                 .oldStatus(null)
                 .newStatus(savedProfessor.getStatus())
                 .newPosition(savedProfessor.getPosition())
@@ -286,9 +297,10 @@ public class AdminService {
                 .build();
     }
 
-    // 관리자 정보 추가
+    // 관리자 계정 등록
     @Transactional
     public MemberCreateRes createAdmin(AdminCreateReq req, MultipartFile pic, Long updaterCode) {
+        validateEmployedAdmin(updaterCode);
         Member member = createMember(req, pic, EnumMemberRole.ADMIN);
 
         Admin newAdmin = Admin.builder()
@@ -301,7 +313,7 @@ public class AdminService {
         // 신규입사 이력 저장
         adminHistoryRepository.save(AdminHistory.builder()
                 .admin(savedAdmin)
-                .changeType("신규입사")
+                .changeType("신규 입사")
                 .oldStatus(null)
                 .newStatus(savedAdmin.getStatus())
                 .startDate(member.getEntryDate())
@@ -313,7 +325,8 @@ public class AdminService {
                 .build();
     }
 
-    public MemberProfileRes getMemberProfile(Long memberCode) {
+    public MemberProfileRes getMemberProfile(Long memberCode, Long requesterCode) {
+        validateEmployedAdmin(requesterCode);
         EnumMemberRole role = getRoleFromMemberCode(memberCode);
         return memberService.getMyProfile(memberCode, role);
     }
@@ -332,7 +345,7 @@ public class AdminService {
     // 학생 계정 개인 정보 수정
     @Transactional
     public void updateStudent(Long memberCode, Long updaterCode, AdminStudentUpdateReq req, MultipartFile pic) {
-
+        validateEmployedAdmin(updaterCode);
         // 공통 필드 업데이트
         Member member = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
         String oldName = member.getName();
@@ -403,7 +416,7 @@ public class AdminService {
     // 교수 계정 정보 수정
     @Transactional
     public void updateProfessor(Long memberCode, Long updaterCode, AdminProfessorUpdateReq req, MultipartFile pic) {
-
+        validateEmployedAdmin(updaterCode);
         // 공통 필드 업데이트
         Member member = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
         String oldName = member.getName();
@@ -446,7 +459,7 @@ public class AdminService {
     // 관리자 계정 정보 수정
     @Transactional
     public void updateAdmin(Long memberCode, Long updaterCode, AdminMemberUpdateReq req, MultipartFile pic) {
-        Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
+        validateEmployedAdmin(updaterCode);
         Member member = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         String oldName = member.getName();
@@ -467,6 +480,7 @@ public class AdminService {
 
     @Transactional
     public void updateAdminStatus(Long memberCode, Long updaterCode, StatusUpdateAdminReq req){
+        validateEmployedAdmin(updaterCode);
         Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
         EnumAdminStatus oldStatus = admin.getStatus();
         EnumAdminStatus newStatus = req.getStatus();
@@ -523,6 +537,7 @@ public class AdminService {
 
     @Transactional
     public void updateProfessorStatus(Long memberCode, Long updaterCode, StatusUpdateProfessorReq req){
+        validateEmployedAdmin(updaterCode);
         Professor professor = professorRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.PROFESSOR_NOT_FOUND));
         EnumProfessorStatus oldStatus = professor.getStatus();
         EnumProfessorStatus newStatus = req.getStatus();
@@ -618,6 +633,7 @@ public class AdminService {
 
     @Transactional
     public void updateStudentStatus(Long memberCode, Long updaterCode, StatusUpdateStudentReq req){
+        validateEmployedAdmin(updaterCode);
         Student student = studentRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND));
         EnumStudentStatus oldStatus = student.getStatus();
         EnumStudentStatus newStatus = req.getStatus();
@@ -701,7 +717,8 @@ public class AdminService {
     }
     // 관리자 상태 변경 이력 조회
     @Transactional(readOnly = true)
-    public List<AdminHistoryRes> findStatusHistory(Long memberCode){
+    public List<AdminHistoryRes> findStatusHistory(Long memberCode, Long requesterCode){
+        validateEmployedAdmin(requesterCode);
         if (!adminRepository.existsById(memberCode)) {
             throw new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND);
         }
@@ -725,10 +742,7 @@ public class AdminService {
     // 전공 변경 신청 목록 전체 조회 (status/size 파라미터 선택 가능)
     @Transactional(readOnly = true)
     public List<AdminMajorRequestListRes> findMajorRequests(Long memberCode, String status, Integer size) {
-        Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
-        if (admin.getStatus() != EnumAdminStatus.EMPLOYMENT) {
-            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
-        }
+        validateEmployedAdmin(memberCode);
         Stream<AdminMajorRequestListRes> stream = majorRequestRepository.findAllByFilter().stream();
         if (status != null) stream = stream.filter(r -> status.equals(r.getStatus()));
         if (size != null && size > 0) return stream.limit(size).toList();
@@ -738,10 +752,7 @@ public class AdminService {
     // 전공 변경 신청 상세 조회 (신청 당시 전공 정보는 MajorRequest에 스냅샷으로 저장된 값 사용)
     @Transactional(readOnly = true)
     public AdminMajorRequestDetailRes findMajorRequestDetail( Long requestId, Long memberCode ) {
-        Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
-        if(admin.getStatus() != EnumAdminStatus.EMPLOYMENT ){
-            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
-        }
+        validateEmployedAdmin(memberCode);
         AdminMajorRequestDetailDto detail = majorRequestRepository.findDetailByRequestId(requestId)
                 .orElseThrow(() -> new BusinessException(RequestErrorCode.NOT_MAJOR_REQUEST));
 
@@ -773,11 +784,7 @@ public class AdminService {
     // 전공 변경 신청 처리
     @Transactional
     public void processMajorRequest(Long requestId, AdminMajorRequestProcessReq req, Long updaterCode) {
-        Admin admin = adminRepository.findById(updaterCode)
-                .orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
-        if (admin.getStatus() != EnumAdminStatus.EMPLOYMENT) {
-            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
-        }
+        validateEmployedAdmin(updaterCode);
         // APPROVED, REJECTED 외 상태는 처리 불가
         if (req.getStatus() != EnumApprovalStatus.APPROVED && req.getStatus() != EnumApprovalStatus.REJECTED) {
             throw new BusinessException(CommonErrorCode.INVALID_INPUT_VALUE);
@@ -852,10 +859,7 @@ public class AdminService {
     // 전공 변경 신청서 파일 다운로드 (관리자 — 소유권 제한 없음)
     @Transactional(readOnly = true)
     public ResponseEntity<Resource> findMajorRequestFile( Long requestId, Long memberCode) {
-        Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
-        if(admin.getStatus() != EnumAdminStatus.EMPLOYMENT ){
-            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
-        }
+        validateEmployedAdmin(memberCode);
         MajorRequest request = majorRequestRepository.findById(requestId)
                 .orElseThrow(() -> new BusinessException(RequestErrorCode.NOT_MAJOR_REQUEST));
         if (request.getFile() == null) {
@@ -869,11 +873,7 @@ public class AdminService {
     // 특정 학생의 전공 변경 이력 조회 (관리자용)
     @Transactional(readOnly = true)
     public List<AdminStudentMajorHistoryRes> findStudentMajorHistory(Long studentCode, Long adminCode) {
-        Admin admin = adminRepository.findById(adminCode)
-                .orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
-        if (admin.getStatus() != EnumAdminStatus.EMPLOYMENT) {
-            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
-        }
+        validateEmployedAdmin(adminCode);
         if (!studentRepository.existsById(studentCode)) {
             throw new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND);
         }
@@ -883,10 +883,7 @@ public class AdminService {
     // 학적 변경 신청 목록 전체 조회 (status/type/size 파라미터 선택 가능)
     @Transactional(readOnly = true)
     public List<AdminStatusRequestListRes> findStatusRequests(Long memberCode, String status, String type, Integer size) {
-        Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
-        if (admin.getStatus() != EnumAdminStatus.EMPLOYMENT) {
-            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
-        }
+        validateEmployedAdmin(memberCode);
         Stream<AdminStatusRequestListRes> stream = statusRequestRepository.findAllByFilter().stream();
         if (status != null) stream = stream.filter(r -> status.equals(r.getStatus()));
         if (type != null) stream = stream.filter(r -> type.equals(r.getType()));
@@ -896,10 +893,7 @@ public class AdminService {
     // 학적 변경 신청 상세 조회
     @Transactional(readOnly = true)
     public AdminStatusRequestDetailRes findStatusRequestDetail(Long requestId, Long memberCode ) {
-        Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
-        if(admin.getStatus() != EnumAdminStatus.EMPLOYMENT ){
-            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
-        }
+        validateEmployedAdmin(memberCode);
         AdminStatusRequestDetailDto detail = statusRequestRepository.findDetailByRequestId(requestId)
                 .orElseThrow(() -> new BusinessException(RequestErrorCode.NOT_STATUS_REQUEST));
 
@@ -932,10 +926,7 @@ public class AdminService {
     // 학적 변경 신청서 파일 다운로드 (관리자 — 소유권 제한 없음)
     @Transactional(readOnly = true)
     public ResponseEntity<Resource> findStatusRequestFile( Long requestId, Long memberCode) {
-        Admin admin = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
-        if(admin.getStatus() != EnumAdminStatus.EMPLOYMENT ){
-            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
-        }
+        validateEmployedAdmin(memberCode);
         StatusRequest request = statusRequestRepository.findById(requestId)
                 .orElseThrow(() -> new BusinessException(RequestErrorCode.NOT_STATUS_REQUEST));
         if (request.getFile() == null) {
@@ -948,11 +939,7 @@ public class AdminService {
     // 학적 변경 신청 처리
     @Transactional
     public void processStatusRequest(Long requestId, AdminStatusRequestProcessReq req, Long updaterCode) {
-        Admin admin = adminRepository.findById(updaterCode)
-                .orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
-        if (admin.getStatus() != EnumAdminStatus.EMPLOYMENT) {
-            throw new BusinessException(MemberErrorCode.ADMIN_NOT_EMPLOYED);
-        }
+        validateEmployedAdmin(updaterCode);
 
         // APPROVED, REJECTED 외 상태는 처리 불가
         if (req.getStatus() != EnumApprovalStatus.APPROVED && req.getStatus() != EnumApprovalStatus.REJECTED) {

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -1019,11 +1019,21 @@ public class AdminService {
             // 학생 상태 업데이트
             student.updateStatus(newStatus);
 
-            // 자퇴 승인 시 자퇴 처리일 기록
+            // 자퇴 승인 시
             if (newStatus == EnumStudentStatus.QUIT) {
+                // 자퇴 처리일 기록
                 Member member = memberRepository.findById(studentCode)
                         .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
                 member.setExitDate(LocalDate.now());
+
+                // 로그인 불가 처리 처리
+                AuthMemberEvent authEvent = AuthMemberEvent.builder()
+                        .memberCode(student.getMemberCode())
+                        .isActive(false)
+                        .eventType(EventType.E_UPDATED)
+                        .updateType(UpdateType.DEACTIVATE)
+                        .build();
+                outboxService.saveToOutbox(MemberTopic.AUTH_MEMBER, student.getMemberCode(), authEvent);
             }
 
             // StudentEvent Outbox 저장

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -958,6 +958,18 @@ public class AdminService {
             Student student = studentRepository.findById(studentCode).orElseThrow(() -> new BusinessException(MemberErrorCode.STUDENT_NOT_FOUND));
             EnumStudentStatus oldStatus = student.getStatus();
 
+            // 신청 유형과 현재 학적 상태 정합성 검증
+            // 신청 시점 이후 관리자 직접 변경 등으로 상태가 달라진 경우 방어
+            if (request.getType() == EnumStatusRequestType.ABSENCE && oldStatus != EnumStudentStatus.ENROLLED) {
+                throw new BusinessException(MemberErrorCode.INVALID_STATUS_FOR_REQUEST);
+            }
+            if (request.getType() == EnumStatusRequestType.RETURN && oldStatus != EnumStudentStatus.ABSENCE) {
+                throw new BusinessException(MemberErrorCode.INVALID_STATUS_FOR_REQUEST);
+            }
+            if (request.getType() == EnumStatusRequestType.QUIT && oldStatus != EnumStudentStatus.ENROLLED) {
+                throw new BusinessException(MemberErrorCode.INVALID_STATUS_FOR_REQUEST);
+            }
+
             // 변화값
             EnumStudentStatus newStatus;
             String changeType;

--- a/member-service/src/main/java/com/green/member/application/member/MemberService.java
+++ b/member-service/src/main/java/com/green/member/application/member/MemberService.java
@@ -55,11 +55,8 @@ public class MemberService {
 
     // 관리자 정보 조회
     public AdminProfileRes findAdmin(Long memberCode, EnumMemberRole role){
-        log.info("findAdmin 진입, memberCode: {}", memberCode);
         Member memberInfo = memberRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
-        log.info("memberInfo: {}", memberInfo);
         Admin adminInfo = adminRepository.findById(memberCode).orElseThrow(() -> new BusinessException(MemberErrorCode.ADMIN_NOT_FOUND));
-        log.info("adminInfo: {}", adminInfo);
 
         return AdminProfileRes.builder()
                 .memberCode(memberInfo.getMemberCode())
@@ -105,8 +102,6 @@ public class MemberService {
         String oldAddress = member.getAddress();
         String oldDetailAddress = member.getDetailAddress();
         String oldPic = member.getPic();
-
-        log.info("oldEmail: {}, reqEmail: {}", oldEmail, req.getEmail());
 
         // 공통 필드 업데이트
         member.updateCommon(

--- a/member-service/src/main/java/com/green/member/exception/MemberErrorCode.java
+++ b/member-service/src/main/java/com/green/member/exception/MemberErrorCode.java
@@ -19,6 +19,7 @@ public enum MemberErrorCode implements ErrorCode {
     , ALREADY_DISMISSED("M009", "이미 퇴임한 교수입니다.", HttpStatus.BAD_REQUEST)
     , ALREADY_TERMINATED("M010", "퇴학 또는 자퇴 처리된 학생입니다.", HttpStatus.BAD_REQUEST)
     , ADMIN_NOT_EMPLOYED("M011", "처리 권한이 없습니다.", HttpStatus.FORBIDDEN)
+    , INVALID_STATUS_FOR_REQUEST("M012", "현재 학적 상태에서 처리할 수 없는 신청입니다.", HttpStatus.CONFLICT)
     ;
     private final String code;
     private final String message;

--- a/member-service/src/main/java/com/green/member/kafka/GraduationResponseConsumer.java
+++ b/member-service/src/main/java/com/green/member/kafka/GraduationResponseConsumer.java
@@ -35,7 +35,7 @@ public class GraduationResponseConsumer {
 
     @Transactional
     @KafkaListener(topics = MemberTopic.GRADUATION_RESPONSE, groupId = "member-service-group")
-    public boolean consume(GraduationCheckResponseEvent event) {
+    public void consume(GraduationCheckResponseEvent event) {
         Long studentCode = event.getStudentCode();
         Integer totalCredits = event.getTotalCredits();
 
@@ -44,25 +44,25 @@ public class GraduationResponseConsumer {
         if (totalCredits == null || totalCredits < GRADUATION_CREDIT_REQUIREMENT) {
             log.info("[졸업 처리] studentCode={} 졸업 조건 미충족 ({}/{}학점)",
                     studentCode, totalCredits, GRADUATION_CREDIT_REQUIREMENT);
-            return false;
+            return;
         }
 
         Student student = studentRepository.findById(studentCode).orElse(null);
         if (student == null) {
             log.warn("[졸업 처리] studentCode={} 학생 없음 - 건너뜀", studentCode);
-            return false;
+            return;
         }
         // 재학 상태가 아니면 처리 안 함 (중복 처리 방어)
         if (student.getStatus() != EnumStudentStatus.ENROLLED) {
             log.info("[졸업 처리] studentCode={} 재학 상태 아님 ({}) - 건너뜀",
                     studentCode, student.getStatus());
-            return false;
+            return;
         }
 
         Member member = memberRepository.findById(studentCode).orElse(null);
         if (member == null) {
             log.warn("[졸업 처리] studentCode={} 회원 없음 - 건너뜀", studentCode);
-            return false;
+            return;
         }
 
         EnumStudentStatus oldStatus = student.getStatus();
@@ -97,6 +97,5 @@ public class GraduationResponseConsumer {
         );
 
         log.info("[졸업 처리] 완료 - studentCode={} 취득학점={}학점", studentCode, totalCredits);
-        return true;
     }
 }


### PR DESCRIPTION
## 관련 이슈 #215

## 작업 내용

###  1. 자퇴 승인 시 처리 누락 2건
  학생 신청 승인 경로에 누락되어 있었음
  - exitDate 미설정 → 자퇴 승인 시 member.exitDate DB 미기록 수정
  - DEACTIVATE 이벤트 미발행 → 자퇴 승인 후 로그인 토큰 즉시 무효화 처리 추가

###  2. 학적 변경 신청 승인 시점 상태 정합성 미검증
  신청 후 관리자 직접 변경 등 다른 경로로 학적 상태가 변경된 경우, 기존 신청을 승인하면 잘못된 상태로 덮어씌워지는 문제
  - 신청 유형별 현재 상태 검증 로직 추가
  - 에러코드 M012 INVALID_STATUS_FOR_REQUEST 신규 추가

###  3. GraduationResponseConsumer 반환 타입 수정

###  4. AdminService 재직 관리자 검증 일괄 적용
  일부 메서드에만 인라인으로 존재하던 EMPLOYMENT 체크가 누락된 메서드 추가

###  5. MemberService 디버그 로그 제거