### PR TITLE
[feat] 강의평가기간 및 성적이의신청 기간에 따른 성적 조회까지 작업 완료

### DIFF
--- a/academic-service/src/main/resources/application.yaml
+++ b/academic-service/src/main/resources/application.yaml
@@ -12,6 +12,10 @@ mybatis:
     map-underscore-to-camel-case: true
 
 spring:
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true   # 프론트 page=1 → Spring 내부 page=0 자동 변환
   config:
     import:
       - optional:classpath:application-common.yaml

--- a/core-service/src/main/java/com/green/core/application/grade/GradeAppealRepository.java
+++ b/core-service/src/main/java/com/green/core/application/grade/GradeAppealRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -19,13 +22,18 @@ public interface GradeAppealRepository extends JpaRepository<GradesAppeal, Long>
     List<GradesAppeal> findByMemberCodeWithLecture(@Param("memberCode") Long memberCode);
 
     // 교수 담당 강의 전체 이의신청 목록
-    @Query("SELECT a FROM GradesAppeal a " +
-           "JOIN FETCH a.grade g " +
-           "JOIN FETCH g.course c " +
-           "JOIN FETCH c.lecture l " +
-           "WHERE l.memberCode = :professorCode " +
-           "ORDER BY a.createdAt DESC")
-    List<GradesAppeal> findByProfessorCodeWithDetails(@Param("professorCode") Long professorCode);
+    @Query(
+        value = "SELECT a FROM GradesAppeal a " +
+                "JOIN FETCH a.grade g " +
+                "JOIN FETCH g.course c " +
+                "JOIN FETCH c.lecture l " +
+                "WHERE l.memberCode = :professorCode " +
+                "ORDER BY a.createdAt DESC",
+        countQuery = "SELECT COUNT(a) FROM GradesAppeal a " +
+                     "JOIN a.grade g JOIN g.course c JOIN c.lecture l " +
+                     "WHERE l.memberCode = :professorCode"
+    )
+    Page<GradesAppeal> findByProfessorCodeWithDetails(@Param("professorCode") Long professorCode, Pageable pageable);
 
     // 특정 이의신청 상세 조회 (FETCH JOIN 포함)
     @Query("SELECT a FROM GradesAppeal a " +

--- a/core-service/src/main/java/com/green/core/application/grade/GradeController.java
+++ b/core-service/src/main/java/com/green/core/application/grade/GradeController.java
@@ -13,6 +13,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
 import java.util.List;
 
 // [수정] 잘못된 /api/calendars 경로 → 교수 성적 API로 교체
@@ -49,9 +52,11 @@ public class GradeController {
 
     // 교수 이의신청 목록 조회
     @GetMapping("/appeals")
-    public ResponseEntity<ResultResponse<List<GradeAppealProListRes>>> getProfessorAppealList() {
+    public ResponseEntity<ResultResponse<Page<GradeAppealProListRes>>> getProfessorAppealList(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size) {
         return ResponseEntity.ok(new ResultResponse<>("이의신청 목록 조회 성공",
-                gradeService.getProfessorAppealList()));
+                gradeService.getProfessorAppealList(PageRequest.of(page - 1, size))));
     }
 
     // 교수 이의신청 상세 조회

--- a/core-service/src/main/java/com/green/core/application/grade/GradeEvalRepository.java
+++ b/core-service/src/main/java/com/green/core/application/grade/GradeEvalRepository.java
@@ -1,11 +1,23 @@
 package com.green.core.application.grade;
 
 import com.green.core.entity.lecture.LectureEvaluation;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Set;
 
 // [추가] 강의평가 완료 여부 확인용 — lecture_evaluation 테이블 읽기 전용
 public interface GradeEvalRepository extends JpaRepository<LectureEvaluation, Long> {
 
     // createdAt IS NOT NULL = 평가 제출 완료 (null = 미완료)
     boolean existsByCourse_CourseIdAndCreatedAtIsNotNull(Long courseId);
+
+    // 성적 목록 조회용: 완료된 courseId Set 일괄 조회 (N+1 방지)
+    @Query("SELECT e.course.courseId FROM LectureEvaluation e WHERE e.course.courseId IN :courseIds AND e.createdAt IS NOT NULL")
+    Set<Long> findCompletedCourseIds(@Param("courseIds") List<Long> courseIds);
+
+    // 성적 상세조회 gate용: 학생의 미완료 평가가 하나라도 있으면 true
+    boolean existsByCourse_StudentCodeAndCreatedAtIsNull(Long studentCode);
 }

--- a/core-service/src/main/java/com/green/core/application/grade/GradeService.java
+++ b/core-service/src/main/java/com/green/core/application/grade/GradeService.java
@@ -28,6 +28,9 @@ import com.green.core.exception.GradeErrorCode;
 import com.green.core.repository.ProfessorCacheRepository;
 import com.green.core.repository.StudentCacheRepository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -471,10 +474,9 @@ public class GradeService {
 
     // ── 교수 이의신청 목록 조회 (GET /professor/grades/appeals) ──────────────
     @Transactional(readOnly = true)
-    public List<GradeAppealProListRes> getProfessorAppealList() {
+    public Page<GradeAppealProListRes> getProfessorAppealList(Pageable pageable) {
         Long professorCode = MemberContext.get().memberCode();
-        return gradeAppealRepository.findByProfessorCodeWithDetails(professorCode)
-                .stream()
+        return gradeAppealRepository.findByProfessorCodeWithDetails(professorCode, pageable)
                 .map(a -> {
                     var course  = a.getGrade().getCourse();
                     var lecture = course.getLecture();
@@ -490,8 +492,7 @@ public class GradeService {
                             a.getStatus().getCode(),
                             a.getCreatedAt()
                     );
-                })
-                .toList();
+                });
     }
 
     // ── 교수 이의신청 상세 조회 (GET /professor/grades/appeals/{courseId}) ────

--- a/core-service/src/main/java/com/green/core/application/grade/GradeService.java
+++ b/core-service/src/main/java/com/green/core/application/grade/GradeService.java
@@ -321,11 +321,16 @@ public class GradeService {
             if (majorTotalCount == 0) { majorTotalCount = 1; majorRank = 1; }
         }
 
+        boolean isAppealPeriod;
+        try { schedulePeriodValidator.checkGradeAppeal(); isAppealPeriod = true; }
+        catch (BusinessException e) { isAppealPeriod = false; }
+
         return new GradeStudentDetailRes(
                 studentInfo,
                 gradeList,
                 new GradeStudentDetailRes.Summary(averageGpa, convertedScore, totalCredits,
-                        averageScore, averageGrade, majorRank, majorTotalCount));
+                        averageScore, averageGrade, majorRank, majorTotalCount),
+                isAppealPeriod);
     }
 
     // ── 학생 이의신청 내역 조회 (GET /student/grades/appeals/my) ─────────────────
@@ -395,6 +400,8 @@ public class GradeService {
     // ── API-GPA-07: 이의신청 제출 (POST /student/grades/{gradeId}/appeal) ──────
     @Transactional
     public void submitAppeal(Long gradeId, GradeAppealReq req) {
+        schedulePeriodValidator.checkGradeAppeal();
+
         Long studentCode = MemberContext.get().memberCode();
 
         Grade grade = gradeRepository.findById(gradeId)

--- a/core-service/src/main/java/com/green/core/application/grade/GradeService.java
+++ b/core-service/src/main/java/com/green/core/application/grade/GradeService.java
@@ -30,11 +30,14 @@ import com.green.core.repository.StudentCacheRepository;
 
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import com.green.core.scheduleValidator.SchedulePeriodValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 // [추가] 성적 서비스 — 교수 성적 조회/입력 구현 (학생 성적 조회는 추후 추가)
 @Service
@@ -47,8 +50,10 @@ public class GradeService {
     private final GradeMajorRepository gradeMajorRepository;
     private final GradeAppealRepository gradeAppealRepository;
     private final GradeAppealHistoryRepository gradeAppealHistoryRepository;
+    private final GradeEvalRepository gradeEvalRepository;
     private final StudentCacheRepository studentCacheRepository;
     private final ProfessorCacheRepository professorCacheRepository;
+    private final SchedulePeriodValidator schedulePeriodValidator;
 
     // ── 교수 담당 강의 목록 조회 (성적 관리 강의 선택 화면용) ─────────────────────
     @Transactional(readOnly = true)
@@ -155,10 +160,21 @@ public class GradeService {
             grades = gradeRepository.findByStudentCode(studentCode);
         }
 
+        boolean isEvalPeriod;
+        try { schedulePeriodValidator.checkLectureEvaluation(); isEvalPeriod = true; }
+        catch (BusinessException e) { isEvalPeriod = false; }
+
+        List<Long> courseIds = grades.stream().map(Grade::getCourseId).toList();
+        // 강의평가 기간이 아니면 모든 과목을 완료로 처리 (기간 종료 후 성적 공개)
+        Set<Long> completedIds = (!isEvalPeriod || courseIds.isEmpty())
+                ? new java.util.HashSet<>(courseIds)
+                : gradeEvalRepository.findCompletedCourseIds(courseIds);
+
         List<GradeStudentRes.GradeItem> gradeList = grades.stream().map(g -> {
             var course   = g.getCourse();
             var lecture  = course.getLecture();
             EnumGradeLetter letter = g.getGradeLetter();
+            boolean evalCompleted = completedIds.contains(g.getCourseId());
             return new GradeStudentRes.GradeItem(
                     g.getCourseId(),
                     course.getYear(),
@@ -166,8 +182,9 @@ public class GradeService {
                     lecture.getLectureName(),
                     lecture.getCredit(),
                     lecture.getLectureType().getValue(),
-                    letter != null ? letter.getCode()   : null,
-                    letter != null ? (letter == EnumGradeLetter.F ? 0.0 : g.getTotalScore() * 4.5 / 100.0) : null
+                    (letter != null && evalCompleted) ? letter.getCode() : null,
+                    (letter != null && evalCompleted) ? (letter == EnumGradeLetter.F ? 0.0 : g.getTotalScore() * 4.5 / 100.0) : null,
+                    evalCompleted
             );
         }).toList();
 
@@ -203,6 +220,16 @@ public class GradeService {
     @Transactional(readOnly = true)
     public GradeStudentDetailRes getStudentAllGrades() {
         Long studentCode = MemberContext.get().memberCode();
+
+        // 강의평가 기간 중 미완료 과목이 하나라도 있으면 접근 차단
+        boolean isEvalPeriodForDetail;
+        try { schedulePeriodValidator.checkLectureEvaluation(); isEvalPeriodForDetail = true; }
+        catch (BusinessException e) { isEvalPeriodForDetail = false; }
+
+        if (isEvalPeriodForDetail
+                && gradeEvalRepository.existsByCourse_StudentCodeAndCreatedAtIsNull(studentCode)) {
+            throw new BusinessException(GradeErrorCode.EVALUATION_NOT_COMPLETED);
+        }
 
         List<Grade> grades = gradeRepository.findByStudentCode(studentCode);
 

--- a/core-service/src/main/java/com/green/core/application/grade/model/GradeStudentDetailRes.java
+++ b/core-service/src/main/java/com/green/core/application/grade/model/GradeStudentDetailRes.java
@@ -13,6 +13,7 @@ public class GradeStudentDetailRes {
     private StudentInfo     studentInfo;
     private List<GradeItem> gradeList;
     private Summary         summary;
+    private boolean         appealPeriod;
 
     @Getter
     @AllArgsConstructor

--- a/core-service/src/main/java/com/green/core/application/grade/model/GradeStudentRes.java
+++ b/core-service/src/main/java/com/green/core/application/grade/model/GradeStudentRes.java
@@ -22,8 +22,9 @@ public class GradeStudentRes {
         private String lectureName;
         private Integer lectureCredit;
         private String lectureType;
-        private String lectureGrade;   // null = 성적 미입력
-        private Double lectureRating;  // null = 성적 미입력
+        private String lectureGrade;   // null = 성적 미입력 또는 강의평가 미완료
+        private Double lectureRating;  // null = 성적 미입력 또는 강의평가 미완료
+        private boolean evalCompleted; // 강의평가 완료 여부
     }
 
     @Getter


### PR DESCRIPTION
## 작업내용

- 학생은 강의평가를 완료해야 해당 강의의 등급과 평점을 확인할 수 있다.
- 학생은 이번년도 이번학기 나의 수강강의의 모든 강의평가를 완료해야 성적 상세조회가 가능하다.
- 강의평가 기간이 지나면 강의평가 여부와 상관없이 성적조회와 성적상세조회가 가능하다.
- 학생은 성적이의신청기한에만 이의신청을 할 수 있다.
- 이의신청이 아닌 기한에는 이의신청을 하지 못하도록 탭을 숨김처리 한다.