### PR TITLE
fix(course): 수강취소 soft-delete 적용 및 나의 강의관리 동결 조회 수정

### DIFF
--- a/core-service/src/main/java/com/green/core/application/course/CourseRepository.java
+++ b/core-service/src/main/java/com/green/core/application/course/CourseRepository.java
@@ -10,17 +10,17 @@ import java.util.Optional;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
 
-    // API-ENRL-03: 중복 신청 확인
-    boolean existsByStudentCodeAndLecture_LectureIdAndYearAndSemester(
+    // API-ENRL-03: 중복 신청 확인 (활성 수강만)
+    boolean existsByStudentCodeAndLecture_LectureIdAndYearAndSemesterAndIsDelFalse(
             Long studentCode, Long lectureId, Integer year, Integer semester
     );
 
-    // API-ENRL-03: 수강 정원 현재 인원 조회
-    int countByLecture_LectureIdAndYearAndSemester(
+    // API-ENRL-03: 수강 정원 현재 인원 조회 (활성 수강만)
+    int countByLecture_LectureIdAndYearAndSemesterAndIsDelFalse(
             Long lectureId, Integer year, Integer semester
     );
 
-    // API-ENRL-03: 학기 총 신청 학점 합산
+    // API-ENRL-03: 학기 총 신청 학점 합산 (활성 수강만)
     @Query("""
             SELECT COALESCE(SUM(l.credit), 0)
             FROM Course c
@@ -28,6 +28,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
             WHERE c.studentCode = :studentCode
               AND c.year = :year
               AND c.semester = :semester
+              AND c.isDel = false
             """)
     int sumCreditByStudentCodeAndYearAndSemester(
             @Param("studentCode") Long studentCode,
@@ -35,7 +36,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
             @Param("semester") Integer semester
     );
 
-    // API-ENRL-03: 시간표 중복 확인
+    // API-ENRL-03: 시간표 중복 확인 (활성 수강만)
     @Query("""
             SELECT COUNT(c) > 0
             FROM Course c
@@ -44,6 +45,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
             WHERE c.studentCode = :studentCode
               AND c.year = :year
               AND c.semester = :semester
+              AND c.isDel = false
               AND ls.dayOfWeek = :dayOfWeek
               AND ls.startPeriod <= :endPeriod
               AND ls.endPeriod >= :startPeriod
@@ -57,22 +59,26 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
             @Param("endPeriod") Integer endPeriod
     );
 
-    // API-ENRL-04: 수강 취소 시 본인 강의 조회
-    Optional<Course> findByStudentCodeAndLecture_LectureIdAndYearAndSemester(
+    // API-ENRL-04: 수강 취소 시 활성 수강 조회
+    Optional<Course> findByStudentCodeAndLecture_LectureIdAndYearAndSemesterAndIsDelFalse(
             Long studentCode, Long lectureId, Integer year, Integer semester
     );
 
-    // API-ENRL-02: 내 수강 신청 목록 조회
-    List<Course> findByStudentCodeAndYearAndSemester(
+    // API-ENRL-03: 수강정정 중 재수강신청 시 소프트딜리트된 레코드 조회
+    Optional<Course> findByStudentCodeAndLecture_LectureIdAndYearAndSemesterAndIsDelTrue(
+            Long studentCode, Long lectureId, Integer year, Integer semester
+    );
+
+    // API-ENRL-02: 내 수강 신청 목록 조회 (활성 수강만)
+    List<Course> findByStudentCodeAndYearAndSemesterAndIsDelFalse(
             Long studentCode, Integer year, Integer semester
     );
 
     // ENRL-02 수강신청 목록 조회
-    Optional<Course> findByStudentCodeAndLecture_LectureId(Long studentCode, Long lectureId);
+    Optional<Course> findByStudentCodeAndLecture_LectureIdAndIsDelFalse(Long studentCode, Long lectureId);
 
-
-    // 폐강 시 수강 학생 코드 목록 조회
-    List<Course> findByLecture_LectureIdAndYearAndSemester(
+    // 폐강 시 수강 학생 코드 목록 조회 (활성 수강만)
+    List<Course> findByLecture_LectureIdAndYearAndSemesterAndIsDelFalse(
             Long lectureId, Integer year, Integer semester
     );
 }

--- a/core-service/src/main/java/com/green/core/application/course/CourseService.java
+++ b/core-service/src/main/java/com/green/core/application/course/CourseService.java
@@ -87,7 +87,7 @@ public class CourseService {
                         currentYear, currentSemester, EnumApprovalStatus.APPROVED,
                         lectureType, majorId, academicYear, search, pageable)
                 .map(l -> {
-                    int enrolledCount = courseRepository.countByLecture_LectureIdAndYearAndSemester(
+                    int enrolledCount = courseRepository.countByLecture_LectureIdAndYearAndSemesterAndIsDelFalse(
                             l.getLectureId(), currentYear, currentSemester);
 
                     List<LectureSchedule> schedules = lectureScheduleRepository
@@ -137,11 +137,11 @@ public class CourseService {
         int currentSemester = getCurrentSemester();
 
         List<MyCourseRes> courses = courseRepository
-                .findByStudentCodeAndYearAndSemester(studentCode, currentYear, currentSemester)
+                .findByStudentCodeAndYearAndSemesterAndIsDelFalse(studentCode, currentYear, currentSemester)
                 .stream()
                 .map(c -> {
                     Lecture l = c.getLecture();
-                    int enrolledCount = courseRepository.countByLecture_LectureIdAndYearAndSemester(
+                    int enrolledCount = courseRepository.countByLecture_LectureIdAndYearAndSemesterAndIsDelFalse(
                             l.getLectureId(), currentYear, currentSemester);
 
                     List<LectureSchedule> schedules = lectureScheduleRepository
@@ -261,9 +261,9 @@ public class CourseService {
 
         log.info("4. 학과/학년 조건 확인 완료");
 
-        // 이미 신청된 강의 확인
+        // 이미 신청된 강의 확인 (활성 수강만)
         boolean alreadyEnrolled = courseRepository
-                .existsByStudentCodeAndLecture_LectureIdAndYearAndSemester(
+                .existsByStudentCodeAndLecture_LectureIdAndYearAndSemesterAndIsDelFalse(
                         studentCode, req.getLectureId(), currentYear, currentSemester);
         if (alreadyEnrolled) {
             throw new BusinessException(CourseErrorCode.COURSE_ALREADY_ENROLLED);
@@ -281,13 +281,12 @@ public class CourseService {
                     newSchedule.getEndPeriod());
             if (timeConflict) {
                 throw new BusinessException(CourseErrorCode.COURSE_SCHEDULE_CONFLICT);
-
             }
         }
         log.info("6. 시간표 중복 확인 완료");
 
         // 수강 정원 초과 확인
-        int enrolledCount = courseRepository.countByLecture_LectureIdAndYearAndSemester(
+        int enrolledCount = courseRepository.countByLecture_LectureIdAndYearAndSemesterAndIsDelFalse(
                 req.getLectureId(), currentYear, currentSemester);
         if (enrolledCount >= lecture.getMaxStd()) {
             throw new BusinessException(CourseErrorCode.COURSE_CAPACITY_EXCEEDED);
@@ -303,22 +302,32 @@ public class CourseService {
         }
         log.info("8. 최대 학점 확인 완료 - 현재 {}학점 + 신규 {}학점", currentCredits, newCredits);
 
-        // Course 저장
-        Course course = Course.builder()
-                .studentCode(studentCode)
-                .lecture(lecture)
-                .year(currentYear)
-                .semester(currentSemester)
-                .build();
-        courseRepository.save(course);
-        log.info("9. 수강 신청 저장 완료 - courseId: {}", course.getCourseId());
+        // 수강정정 기간 중 같은 강의를 재신청하는 경우 → 기존 소프트딜리트 레코드 재활성화
+        Course course = courseRepository
+                .findByStudentCodeAndLecture_LectureIdAndYearAndSemesterAndIsDelTrue(
+                        studentCode, req.getLectureId(), currentYear, currentSemester)
+                .orElse(null);
 
-        // Grade Row 즉시 생성
-        Grade grade = Grade.builder()
-                .course(course)
-                .build();
-        gradeRepository.save(grade);
-        log.info("10. 성적 Row 생성 완료 - courseId: {}", course.getCourseId());
+        if (course != null) {
+            course.reactivate();
+            log.info("9. 수강 재활성화 완료 - courseId: {}", course.getCourseId());
+        } else {
+            course = Course.builder()
+                    .studentCode(studentCode)
+                    .lecture(lecture)
+                    .year(currentYear)
+                    .semester(currentSemester)
+                    .build();
+            courseRepository.save(course);
+            log.info("9. 수강 신청 저장 완료 - courseId: {}", course.getCourseId());
+
+            // Grade Row 즉시 생성 (신규 레코드만)
+            Grade grade = Grade.builder()
+                    .course(course)
+                    .build();
+            gradeRepository.save(grade);
+            log.info("10. 성적 Row 생성 완료 - courseId: {}", course.getCourseId());
+        }
 
         // 저장 후 총 학점 반환
         int totalCredits = currentCredits + newCredits;
@@ -340,12 +349,11 @@ public class CourseService {
         Long studentCode = Long.parseLong(request.getHeader("X-Member-Code"));
 
         Course course = courseRepository
-                .findByStudentCodeAndLecture_LectureIdAndYearAndSemester(
+                .findByStudentCodeAndLecture_LectureIdAndYearAndSemesterAndIsDelFalse(
                         studentCode, lectureId, currentYear, currentSemester)
                 .orElseThrow(() -> new BusinessException(CourseErrorCode.COURSE_NOT_FOUND));
 
-        // Course 삭제 시 Grade도 cascade로 함께 삭제됨 (Course 엔티티 @OneToOne cascade = ALL)
-        courseRepository.delete(course);
+        course.softDelete();
         log.info("수강 신청 취소 완료 - lectureId: {}, studentCode: {}", lectureId, studentCode);
     }
 

--- a/core-service/src/main/java/com/green/core/application/lecture/EvaluationService.java
+++ b/core-service/src/main/java/com/green/core/application/lecture/EvaluationService.java
@@ -75,7 +75,7 @@ public class EvaluationService {
                 .orElseThrow(() -> new BusinessException(EvaluationErrorCode.EVALUATION_NOT_FOUND));
 
         // Course 조회 (studentCode + lectureId로)
-        Course course = courseRepository.findByStudentCodeAndLecture_LectureId(
+        Course course = courseRepository.findByStudentCodeAndLecture_LectureIdAndIsDelFalse(
                         memberDto.memberCode(), req.getLectureId())
                 .orElseThrow(() -> new BusinessException(EvaluationErrorCode.EVALUATION_NOT_FOUND));
 

--- a/core-service/src/main/java/com/green/core/application/lecture/LectureAutoCancelService.java
+++ b/core-service/src/main/java/com/green/core/application/lecture/LectureAutoCancelService.java
@@ -40,7 +40,7 @@ public class LectureAutoCancelService {
 
         for (Lecture lecture : lectures) {
             int enrolledCount = courseRepository
-                    .countByLecture_LectureIdAndYearAndSemester(
+                    .countByLecture_LectureIdAndYearAndSemesterAndIsDelFalse(
                             lecture.getLectureId(), year, semester);
 
             double enrollmentRate = (double) enrolledCount / lecture.getMaxStd();
@@ -75,7 +75,7 @@ public class LectureAutoCancelService {
 
                 // 수강 학생 알림
                 List<Course> courses = courseRepository
-                        .findByLecture_LectureIdAndYearAndSemester(
+                        .findByLecture_LectureIdAndYearAndSemesterAndIsDelFalse(
                                 lecture.getLectureId(), year, semester);
 
                 for (Course course : courses) {

--- a/core-service/src/main/java/com/green/core/application/lecture/LectureService.java
+++ b/core-service/src/main/java/com/green/core/application/lecture/LectureService.java
@@ -373,7 +373,7 @@ public class LectureService {
         // 수강 학생들 알림 발송
         int year = lecture.getYear();
         int semester = lecture.getSemester();
-        List<Course> courses = courseRepository.findByLecture_LectureIdAndYearAndSemester(
+        List<Course> courses = courseRepository.findByLecture_LectureIdAndYearAndSemesterAndIsDelFalse(
                 lectureId, year, semester);
 
         for (Course course : courses) {
@@ -418,7 +418,7 @@ public class LectureService {
 
         lecture.changeProfessor(newMemberCode);
 
-        List<Course> courses = courseRepository.findByLecture_LectureIdAndYearAndSemester(
+        List<Course> courses = courseRepository.findByLecture_LectureIdAndYearAndSemesterAndIsDelFalse(
                 lectureId, lecture.getYear(), lecture.getSemester());
         for (Course course : courses) {
             notificationProducer.sendNotification(NotificationEvent.builder()

--- a/core-service/src/main/java/com/green/core/entity/course/Course.java
+++ b/core-service/src/main/java/com/green/core/entity/course/Course.java
@@ -8,6 +8,7 @@ import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -39,6 +40,13 @@ public class Course extends CreatedAt {
     @Column(name = "semester", nullable = false)
     private Integer semester; // 복합 Unique
 
+    @Column(name = "is_del", nullable = false)
+    @Builder.Default
+    private boolean isDel = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     // mappedBy = "course" 는 Grade 엔터티 안에 course라는 필드가 주인이라는 뜻
     @OneToOne(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
     private Grade grade;
@@ -46,4 +54,14 @@ public class Course extends CreatedAt {
     //수강 정정 기간에 취소하면 해당 학생의 출석 데이터도 자동으로 같이 지우기
     @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Attendance> attendances;
+
+    public void softDelete() {
+        this.isDel = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public void reactivate() {
+        this.isDel = false;
+        this.deletedAt = null;
+    }
 }

--- a/core-service/src/main/resources/mappers/LectureMapper.xml
+++ b/core-service/src/main/resources/mappers/LectureMapper.xml
@@ -222,7 +222,15 @@
         AND l.status = 'APPROVED'
         <if test="req.year != null">AND l.year = #{req.year}</if>
         <if test="req.semester != null">AND l.semester = #{req.semester}</if>
-        <if test="req.createdBefore != null">AND c.created_at &lt; #{req.createdBefore}</if>
+        <choose>
+            <when test="req.createdBefore != null">
+                AND c.created_at &lt; #{req.createdBefore}
+                AND (c.is_del = false OR c.deleted_at &gt;= #{req.createdBefore})
+            </when>
+            <otherwise>
+                AND c.is_del = false
+            </otherwise>
+        </choose>
         ORDER BY l.lecture_id DESC
         LIMIT #{req.size} OFFSET #{req.offset}
         ) paged
@@ -241,7 +249,15 @@
         AND l.status = 'APPROVED'
         <if test="req.year != null">AND l.year = #{req.year}</if>
         <if test="req.semester != null">AND l.semester = #{req.semester}</if>
-        <if test="req.createdBefore != null">AND c.created_at &lt; #{req.createdBefore}</if>
+        <choose>
+            <when test="req.createdBefore != null">
+                AND c.created_at &lt; #{req.createdBefore}
+                AND (c.is_del = false OR c.deleted_at &gt;= #{req.createdBefore})
+            </when>
+            <otherwise>
+                AND c.is_del = false
+            </otherwise>
+        </choose>
     </select>
 
     <!-- LEC-08 전체 강의 목록 -->
@@ -413,6 +429,7 @@
         LEFT JOIN professor_cache pc ON l.member_code = pc.member_code
         <include refid="scheduleJoins"/>
         WHERE c.student_code = #{memberCode}
+        AND c.is_del = false
         AND l.status = 'APPROVED'
         <if test="year != null">AND l.year = #{year}</if>
         <if test="semester != null">AND l.semester = #{semester}</if>


### PR DESCRIPTION
- Course 엔티티에 isDel/deletedAt 필드 추가, softDelete()/reactivate() 메서드 구현
- 수강취소 물리삭제 → softDelete로 변경, 수강정정 중 재신청 시 reactivate 처리
- CourseRepository 전체 쿼리에 IsDelFalse 조건 추가 및 메서드명 통일
- findStudentMyLectures: createdBefore 기준 동결 목록 조회 (취소된 강의도 정정기간 시작 전 신청분 표시)
- findStudentTimetable: is_del = false 조건 추가
- CourseService, LectureAutoCancelService, EvaluationService, LectureService 메서드명 변경 반영