### PR TITLE
fix: ScheduleConsumer 역직렬화 방식 String 파싱으로 변경

### DIFF
--- a/member-service/src/main/java/com/green/member/kafka/ScheduleConsumer.java
+++ b/member-service/src/main/java/com/green/member/kafka/ScheduleConsumer.java
@@ -1,5 +1,7 @@
 package com.green.member.kafka;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.green.common.enumcode.EnumScheduleType;
 import com.green.common.kafka.KafkaTopic;
 import com.green.common.kafka.ScheduleEvent;
@@ -18,10 +20,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class ScheduleConsumer {
 
     private final ScheduleCacheRepository scheduleCacheRepository;
+    private final ObjectMapper objectMapper;
 
     @Transactional
     @KafkaListener(topics = KafkaTopic.SCHEDULE, groupId = "member-service-group")
-    public void consume(ScheduleEvent event) {
+    public void consume(String message) throws JsonProcessingException {
+        ScheduleEvent event = objectMapper.readValue(message, ScheduleEvent.class);
+
         // MAJOR_CHANGE, SEMESTER_START, SEMESTER_END만 저장
         if (event.getType() != EnumScheduleType.MAJOR_CHANGE
                 && event.getType() != EnumScheduleType.SEMESTER_START
@@ -43,7 +48,8 @@ public class ScheduleConsumer {
 
     @KafkaListener(topics = KafkaTopic.SCHEDULE_DELETE, groupId = "member-service-group")
     @Transactional
-    public void consumeDelete(ScheduleEvent event) {
+    public void consumeDelete(String message) throws JsonProcessingException {
+        ScheduleEvent event = objectMapper.readValue(message, ScheduleEvent.class);
         log.info("Schedule 삭제 이벤트 수신: {}", event);
         scheduleCacheRepository.deleteByScheduleId(event.getScheduleId());
     }


### PR DESCRIPTION
- kafkaTemplate 직접 발행 시 타입 헤더 없어 ScheduleEvent 변환 실패
- consume/consumeDelete 파라미터를 String으로 변경 후 ObjectMapper로 직접 파싱
- core-service, member-service 양쪽 모두 적용