### PR TITLE
[fix] 공지사항 검토부분 수정 완료

### DIFF
--- a/academic-service/src/main/java/com/green/academic/application/announcement/AnnouncementController.java
+++ b/academic-service/src/main/java/com/green/academic/application/announcement/AnnouncementController.java
@@ -5,6 +5,8 @@ import com.green.academic.application.announcement.model.AnnoListReq;
 import com.green.academic.application.announcement.model.AnnoListRes;
 import com.green.common.model.ResultResponse;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -17,6 +19,13 @@ import org.springframework.web.bind.annotation.*;
 public class AnnouncementController {
 
     private final AnnouncementService announcementService;
+
+    // 공지사항이 존재하는 연도 목록 (역할별)
+    @GetMapping("/years")
+    public ResponseEntity<ResultResponse<List<Integer>>> getYears() {
+        return ResponseEntity.ok(new ResultResponse<>("연도 조회 성공",
+                announcementService.getAnnouncementYears()));
+    }
 
     // ANNO-03 공지사항 목록 조회 (학생/교수/관리자 - 역할별 필터)
     @GetMapping

--- a/academic-service/src/main/java/com/green/academic/application/announcement/AnnouncementRepository.java
+++ b/academic-service/src/main/java/com/green/academic/application/announcement/AnnouncementRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -43,6 +44,67 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
 
     // 상세조회 (삭제되지 않은 것만)
     Optional<Announcement> findByAnnoIdAndIsDelFalse(Long annoId);
+
+    // 관리자: 전체 조회 + 제목검색·연도 범위 (targetRole 없음 — null Enum 바인딩 오류 방지)
+    @Query(value = "SELECT a FROM Announcement a WHERE a.isDel = false " +
+                   "AND (:search IS NULL OR a.title LIKE CONCAT('%',:search,'%')) " +
+                   "AND (:startDate IS NULL OR a.createdAt >= :startDate) " +
+                   "AND (:endDate IS NULL OR a.createdAt < :endDate) " +
+                   "ORDER BY a.createdAt DESC",
+           countQuery = "SELECT COUNT(a) FROM Announcement a WHERE a.isDel = false " +
+                        "AND (:search IS NULL OR a.title LIKE CONCAT('%',:search,'%')) " +
+                        "AND (:startDate IS NULL OR a.createdAt >= :startDate) " +
+                        "AND (:endDate IS NULL OR a.createdAt < :endDate)")
+    Page<Announcement> findAdminAllWithFilters(@Param("search") String search,
+                                               @Param("startDate") LocalDateTime startDate,
+                                               @Param("endDate") LocalDateTime endDate,
+                                               Pageable pageable);
+
+    // 관리자: 특정 targetRole 필터 (role은 항상 non-null)
+    @Query(value = "SELECT a FROM Announcement a WHERE a.isDel = false " +
+                   "AND a.targetRole = :targetRole " +
+                   "AND (:search IS NULL OR a.title LIKE CONCAT('%',:search,'%')) " +
+                   "AND (:startDate IS NULL OR a.createdAt >= :startDate) " +
+                   "AND (:endDate IS NULL OR a.createdAt < :endDate) " +
+                   "ORDER BY a.createdAt DESC",
+           countQuery = "SELECT COUNT(a) FROM Announcement a WHERE a.isDel = false " +
+                        "AND a.targetRole = :targetRole " +
+                        "AND (:search IS NULL OR a.title LIKE CONCAT('%',:search,'%')) " +
+                        "AND (:startDate IS NULL OR a.createdAt >= :startDate) " +
+                        "AND (:endDate IS NULL OR a.createdAt < :endDate)")
+    Page<Announcement> findAdminByRoleWithFilters(@Param("targetRole") EnumTargetRole targetRole,
+                                                   @Param("search") String search,
+                                                   @Param("startDate") LocalDateTime startDate,
+                                                   @Param("endDate") LocalDateTime endDate,
+                                                   Pageable pageable);
+
+    // 학생·교수·비로그인: targetRole IN 리스트 + 제목검색·연도 범위
+    @Query(value = "SELECT a FROM Announcement a WHERE a.isDel = false " +
+                   "AND a.targetRole IN :targetRoles " +
+                   "AND (:search IS NULL OR a.title LIKE CONCAT('%',:search,'%')) " +
+                   "AND (:startDate IS NULL OR a.createdAt >= :startDate) " +
+                   "AND (:endDate IS NULL OR a.createdAt < :endDate) " +
+                   "ORDER BY a.createdAt DESC",
+           countQuery = "SELECT COUNT(a) FROM Announcement a WHERE a.isDel = false " +
+                        "AND a.targetRole IN :targetRoles " +
+                        "AND (:search IS NULL OR a.title LIKE CONCAT('%',:search,'%')) " +
+                        "AND (:startDate IS NULL OR a.createdAt >= :startDate) " +
+                        "AND (:endDate IS NULL OR a.createdAt < :endDate)")
+    Page<Announcement> findByRolesWithFilters(@Param("targetRoles") List<EnumTargetRole> targetRoles,
+                                              @Param("search") String search,
+                                              @Param("startDate") LocalDateTime startDate,
+                                              @Param("endDate") LocalDateTime endDate,
+                                              Pageable pageable);
+
+    // 공지가 존재하는 연도 목록 — 관리자용 (전체)
+    @Query(value = "SELECT DISTINCT YEAR(created_at) FROM announcement WHERE is_del = 0 ORDER BY 1 DESC",
+           nativeQuery = true)
+    List<Integer> findAllDistinctYears();
+
+    // 공지가 존재하는 연도 목록 — 역할별 (target_role IN 조건)
+    @Query(value = "SELECT DISTINCT YEAR(created_at) FROM announcement WHERE is_del = 0 AND target_role IN (:roles) ORDER BY 1 DESC",
+           nativeQuery = true)
+    List<Integer> findDistinctYearsByRoles(@Param("roles") List<String> roles);
 
     // 조회수 직접 증가 (updated_at 갱신 방지)
     @Modifying(clearAutomatically = true)

--- a/academic-service/src/main/java/com/green/academic/application/announcement/AnnouncementService.java
+++ b/academic-service/src/main/java/com/green/academic/application/announcement/AnnouncementService.java
@@ -65,9 +65,9 @@ public class AnnouncementService {
                         : announcementRepository.findAllByIsDelFalseOrderByCreatedAtDesc(pageable);
             }
             case PROFESSOR -> announcementRepository.findByTargetRoleInAndIsDelFalseOrderByCreatedAtDesc(
-                        List.of(EnumTargetRole.PROFESSOR, EnumTargetRole.ALL), pageable);
+                        List.of(EnumTargetRole.PROFESSOR, EnumTargetRole.MEMBER, EnumTargetRole.ALL), pageable);
             case STUDENT   -> announcementRepository.findByTargetRoleInAndIsDelFalseOrderByCreatedAtDesc(
-                        List.of(EnumTargetRole.STUDENT, EnumTargetRole.ALL), pageable);
+                        List.of(EnumTargetRole.STUDENT, EnumTargetRole.MEMBER, EnumTargetRole.ALL), pageable);
         };
         return page.map(a -> new AnnoListRes(a.getAnnoId(), a.getTargetRole().getCode(),
                 a.getTitle(), a.getWriterName(), a.getViewCount(), a.getCreatedAt()));

--- a/academic-service/src/main/java/com/green/academic/application/announcement/AnnouncementService.java
+++ b/academic-service/src/main/java/com/green/academic/application/announcement/AnnouncementService.java
@@ -80,7 +80,8 @@ public class AnnouncementService {
                 .orElseThrow(() -> new BusinessException(AnnouncementErrorCode.ANNOUNCEMENT_NOT_FOUND));
         checkAccess(member, anno);
         announcementRepository.incrementViewCount(annoId);
-        return toDetailRes(anno);
+        return toDetailRes(announcementRepository.findByAnnoIdAndIsDelFalse(annoId)
+                .orElseThrow(() -> new BusinessException(AnnouncementErrorCode.ANNOUNCEMENT_NOT_FOUND)));
     }
 
     public Page<AnnoListRes> getPublicList(Pageable pageable) {
@@ -98,7 +99,8 @@ public class AnnouncementService {
             throw new BusinessException(AnnouncementErrorCode.ANNOUNCEMENT_ACCESS_DENIED);
         }
         announcementRepository.incrementViewCount(annoId);
-        return toDetailRes(anno);
+        return toDetailRes(announcementRepository.findByAnnoIdAndIsDelFalse(annoId)
+                .orElseThrow(() -> new BusinessException(AnnouncementErrorCode.ANNOUNCEMENT_NOT_FOUND)));
     }
 
     private Announcement findOwnAnnouncement(Long annoId) {

--- a/academic-service/src/main/java/com/green/academic/application/announcement/AnnouncementService.java
+++ b/academic-service/src/main/java/com/green/academic/application/announcement/AnnouncementService.java
@@ -84,7 +84,7 @@ public class AnnouncementService {
                         search, startDate, endDate, pageable);
         };
         return page.map(a -> new AnnoListRes(a.getAnnoId(), a.getTargetRole().getCode(),
-                a.getTitle(), a.getWriterName(), a.getViewCount(), a.getCreatedAt()));
+                a.getTitle(), a.getWriterName(), a.getMemberCode(), a.getViewCount(), a.getCreatedAt()));
     }
 
     @Transactional
@@ -105,7 +105,7 @@ public class AnnouncementService {
         return announcementRepository.findByRolesWithFilters(
                         List.of(EnumTargetRole.ALL), searchParam, startDate, endDate, pageable)
                 .map(a -> new AnnoListRes(a.getAnnoId(), a.getTargetRole().getCode(),
-                        a.getTitle(), a.getWriterName(), a.getViewCount(), a.getCreatedAt()));
+                        a.getTitle(), a.getWriterName(), a.getMemberCode(), a.getViewCount(), a.getCreatedAt()));
     }
 
     @Transactional
@@ -143,7 +143,7 @@ public class AnnouncementService {
     private AnnoDetailRes toDetailRes(Announcement anno) {
         return new AnnoDetailRes(
                 anno.getAnnoId(), anno.getTargetRole().getCode(),
-                anno.getTitle(), anno.getContent(), anno.getWriterName(),
+                anno.getTitle(), anno.getContent(), anno.getWriterName(), anno.getMemberCode(),
                 anno.getViewCount(), anno.getCreatedAt(), anno.getUpdatedAt(),
                 List.of()
         );

--- a/academic-service/src/main/java/com/green/academic/application/announcement/AnnouncementService.java
+++ b/academic-service/src/main/java/com/green/academic/application/announcement/AnnouncementService.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -21,6 +22,19 @@ import java.util.List;
 public class AnnouncementService {
 
     private final AnnouncementRepository announcementRepository;
+
+    public List<Integer> getAnnouncementYears() {
+        MemberDto member = MemberContext.get();
+        return switch (member.role()) {
+            case ADMIN     -> announcementRepository.findAllDistinctYears();
+            case PROFESSOR -> announcementRepository.findDistinctYearsByRoles(List.of("PROFESSOR", "MEMBER", "ALL"));
+            case STUDENT   -> announcementRepository.findDistinctYearsByRoles(List.of("STUDENT", "MEMBER", "ALL"));
+        };
+    }
+
+    public List<Integer> getPublicAnnouncementYears() {
+        return announcementRepository.findDistinctYearsByRoles(List.of("ALL"));
+    }
 
     @Transactional
     public AnnoCreateRes create(AnnoCreateReq req) {
@@ -50,24 +64,24 @@ public class AnnouncementService {
 
     public Page<AnnoListRes> getList(AnnoListReq req, Pageable pageable) {
         MemberDto member = MemberContext.get();
+        String search       = req.getSearch() != null && !req.getSearch().isBlank() ? req.getSearch() : null;
+        LocalDateTime startDate = req.getYear() != null ? LocalDateTime.of(req.getYear(), 1, 1, 0, 0) : null;
+        LocalDateTime endDate   = req.getYear() != null ? LocalDateTime.of(req.getYear() + 1, 1, 1, 0, 0) : null;
+
         Page<Announcement> page = switch (member.role()) {
             case ADMIN -> {
-                EnumTargetRole roleFilter = req.getTargetRole() != null
+                EnumTargetRole roleFilter = req.getTargetRole() != null && !req.getTargetRole().isBlank()
                         ? EnumTargetRole.valueOf(req.getTargetRole()) : null;
-                String search = req.getSearch() != null && !req.getSearch().isBlank()
-                        ? req.getSearch() : null;
-                yield (roleFilter != null && search != null)
-                        ? announcementRepository.findByTargetRoleAndSearchAndIsDelFalse(roleFilter, search, pageable)
-                        : (roleFilter != null)
-                        ? announcementRepository.findByTargetRoleAndIsDelFalseOrderByCreatedAtDesc(roleFilter, pageable)
-                        : (search != null)
-                        ? announcementRepository.findAllBySearchAndIsDelFalse(search, pageable)
-                        : announcementRepository.findAllByIsDelFalseOrderByCreatedAtDesc(pageable);
+                yield (roleFilter != null)
+                        ? announcementRepository.findAdminByRoleWithFilters(roleFilter, search, startDate, endDate, pageable)
+                        : announcementRepository.findAdminAllWithFilters(search, startDate, endDate, pageable);
             }
-            case PROFESSOR -> announcementRepository.findByTargetRoleInAndIsDelFalseOrderByCreatedAtDesc(
-                        List.of(EnumTargetRole.PROFESSOR, EnumTargetRole.MEMBER, EnumTargetRole.ALL), pageable);
-            case STUDENT   -> announcementRepository.findByTargetRoleInAndIsDelFalseOrderByCreatedAtDesc(
-                        List.of(EnumTargetRole.STUDENT, EnumTargetRole.MEMBER, EnumTargetRole.ALL), pageable);
+            case PROFESSOR -> announcementRepository.findByRolesWithFilters(
+                        List.of(EnumTargetRole.PROFESSOR, EnumTargetRole.MEMBER, EnumTargetRole.ALL),
+                        search, startDate, endDate, pageable);
+            case STUDENT   -> announcementRepository.findByRolesWithFilters(
+                        List.of(EnumTargetRole.STUDENT, EnumTargetRole.MEMBER, EnumTargetRole.ALL),
+                        search, startDate, endDate, pageable);
         };
         return page.map(a -> new AnnoListRes(a.getAnnoId(), a.getTargetRole().getCode(),
                 a.getTitle(), a.getWriterName(), a.getViewCount(), a.getCreatedAt()));
@@ -84,9 +98,12 @@ public class AnnouncementService {
                 .orElseThrow(() -> new BusinessException(AnnouncementErrorCode.ANNOUNCEMENT_NOT_FOUND)));
     }
 
-    public Page<AnnoListRes> getPublicList(Pageable pageable) {
-        return announcementRepository.findByTargetRoleInAndIsDelFalseOrderByCreatedAtDesc(
-                        List.of(EnumTargetRole.ALL), pageable)
+    public Page<AnnoListRes> getPublicList(String search, Integer year, Pageable pageable) {
+        String searchParam  = search != null && !search.isBlank() ? search : null;
+        LocalDateTime startDate = year != null ? LocalDateTime.of(year, 1, 1, 0, 0) : null;
+        LocalDateTime endDate   = year != null ? LocalDateTime.of(year + 1, 1, 1, 0, 0) : null;
+        return announcementRepository.findByRolesWithFilters(
+                        List.of(EnumTargetRole.ALL), searchParam, startDate, endDate, pageable)
                 .map(a -> new AnnoListRes(a.getAnnoId(), a.getTargetRole().getCode(),
                         a.getTitle(), a.getWriterName(), a.getViewCount(), a.getCreatedAt()));
     }

--- a/academic-service/src/main/java/com/green/academic/application/announcement/PublicAnnouncementController.java
+++ b/academic-service/src/main/java/com/green/academic/application/announcement/PublicAnnouncementController.java
@@ -4,6 +4,8 @@ import com.green.academic.application.announcement.model.AnnoDetailRes;
 import com.green.academic.application.announcement.model.AnnoListRes;
 import com.green.common.model.ResultResponse;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -17,12 +19,21 @@ public class PublicAnnouncementController {
 
     private final AnnouncementService announcementService;
 
+    // 공개 공지사항이 존재하는 연도 목록
+    @GetMapping("/years")
+    public ResponseEntity<ResultResponse<List<Integer>>> getPublicYears() {
+        return ResponseEntity.ok(new ResultResponse<>("연도 조회 성공",
+                announcementService.getPublicAnnouncementYears()));
+    }
+
     // ANNO-06 공개 공지사항 목록 조회 (비로그인, targetRole=ALL만)
     @GetMapping
     public ResponseEntity<ResultResponse<Page<AnnoListRes>>> getPublicList(
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) Integer year,
             @PageableDefault(size = 10) Pageable pageable) {
         return ResponseEntity.ok(new ResultResponse<>("공개 공지사항 목록 조회 성공",
-                announcementService.getPublicList(pageable)));
+                announcementService.getPublicList(search, year, pageable)));
     }
 
     // ANNO-07 공개 공지사항 상세 조회

--- a/academic-service/src/main/java/com/green/academic/application/announcement/model/AnnoDetailRes.java
+++ b/academic-service/src/main/java/com/green/academic/application/announcement/model/AnnoDetailRes.java
@@ -14,6 +14,7 @@ public class AnnoDetailRes {
     private String title;
     private String content;
     private String writerName;
+    private Long writerCode;
     private Integer viewCount;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/academic-service/src/main/java/com/green/academic/application/announcement/model/AnnoListReq.java
+++ b/academic-service/src/main/java/com/green/academic/application/announcement/model/AnnoListReq.java
@@ -8,4 +8,5 @@ import lombok.Setter;
 public class AnnoListReq {
     private String targetRole;
     private String search;
+    private Integer year;
 }

--- a/academic-service/src/main/java/com/green/academic/application/announcement/model/AnnoListRes.java
+++ b/academic-service/src/main/java/com/green/academic/application/announcement/model/AnnoListRes.java
@@ -12,6 +12,7 @@ public class AnnoListRes {
     private String targetRole;
     private String title;
     private String writerName;
+    private Long writerCode;
     private Integer viewCount;
     private LocalDateTime createdAt;
 }

--- a/academic-service/src/main/java/com/green/academic/enumcode/EnumTargetRole.java
+++ b/academic-service/src/main/java/com/green/academic/enumcode/EnumTargetRole.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 public enum EnumTargetRole implements EnumMapperType {
     STUDENT("STUDENT", "학생"),
     PROFESSOR("PROFESSOR", "교수"),
+    MEMBER("MEMBER", "교내 전체"),
     ALL("ALL", "전체"),
     ;
     private final String code;


### PR DESCRIPTION
## 작업내용

- 공지사항 작성간 관리자끼리는 작성자+작성자 코드 출력될 수 있도록 처리.
- 학생/교수/비로그인 사용자는 작성자가 출력안되도록 처리
- 조회수 관련하여 공지사항 클릭 후 목록으로 돌아가야 조회수가 올라가는 버그 수정
- 학생/교수/비로그인 공지사항 목록 출력간에 연도별 및 공지사항 제목 검색기능 추가
- 공지사항 작성간 공지대상에 '교내인원전체' 추가
- 비로그인 공지사항에도 조회수기능 추가
- 공지사항 제목 길어질 경우에 JS(20자 제한) + css 처리로 정해진 글자 또는 화면 크기에 따라 제목 줄임표시