### PR TITLE
fix(member) 배포 환경 설정. 대시보드 응답값 수정. 

### DIFF
--- a/common/src/main/java/com/green/common/enumcode/EnumAdminStatus.java
+++ b/common/src/main/java/com/green/common/enumcode/EnumAdminStatus.java
@@ -1,7 +1,5 @@
-package com.green.member.enumcode;
+package com.green.common.enumcode;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.green.common.enumcode.AbstractEnumCodeConverter;
-import com.green.common.enumcode.EnumMapperType;
 import jakarta.persistence.Converter;
 import lombok.*;
 @Getter

--- a/common/src/main/java/com/green/common/enumcode/EnumAutoConfiguration.java
+++ b/common/src/main/java/com/green/common/enumcode/EnumAutoConfiguration.java
@@ -24,7 +24,8 @@ public class EnumAutoConfiguration {
         log.info("scanPackage: {}", scanPackage);
         // 스캔할 패키지 리스트 준비
         List<String> scanPackages = new ArrayList<>();
-        scanPackages.add(getBasePackage(applicationContext)); //메인 애플리케이션의 패키지 경로를 가져와서 스캔
+        scanPackages.add(getBasePackage(applicationContext)); // 메인 애플리케이션의 패키지 경로를 가져와서 스캔
+        scanPackages.add("com.green.common.enumcode");        // common 공용 enum 항상 포함
         if(scanPackage != null) {
             scanPackages.add(scanPackage);
         }

--- a/common/src/main/java/com/green/common/kafka/member/MemberTopic.java
+++ b/common/src/main/java/com/green/common/kafka/member/MemberTopic.java
@@ -1,9 +1,9 @@
 package com.green.common.kafka.member;
 
 public class MemberTopic {
-    public static final String AUTH_MEMBER          = "auth-member-events";
-    public static final String STUDENT              = "student-events";
-    public static final String PROFESSOR            = "professor-events";
-public static final String GRADUATION_REQUEST   = "graduation-check-request";
-    public static final String GRADUATION_RESPONSE  = "graduation-check-response";
+    public static final String AUTH_MEMBER         = "auth-member-events";
+    public static final String STUDENT             = "student-events";
+    public static final String PROFESSOR           = "professor-events";
+    public static final String GRADUATION_REQUEST  = "graduation-check-request";
+    public static final String GRADUATION_RESPONSE = "graduation-check-response";
 }

--- a/core-service/src/main/java/com/green/core/application/grade/GradeQueryRepository.java
+++ b/core-service/src/main/java/com/green/core/application/grade/GradeQueryRepository.java
@@ -28,7 +28,7 @@ public class GradeQueryRepository {
 
     // 학생의 weighted GPA 계산 (F 포함 전체 성적 기준) (전공변경 신청에 사용)
     public Double calcWeightedGpaByStudentCode(Long studentCode) {
-        return (Double) em.createNativeQuery("""
+        Number result = (Number) em.createNativeQuery("""
                 SELECT COALESCE(
                     SUM(
                         CASE g.grade_letter
@@ -52,5 +52,6 @@ public class GradeQueryRepository {
                 """)
                 .setParameter("studentCode", studentCode)
                 .getSingleResult();
+        return result != null ? result.doubleValue() : null;
     }
 }

--- a/gateway/src/main/resources/application-prod.yaml
+++ b/gateway/src/main/resources/application-prod.yaml
@@ -39,6 +39,11 @@ spring:
               predicates:
                 - Path=/api/member/**, /api/member/**
 
+            - id: member-file
+              uri: http://member-service:80
+              predicates:
+                - Path=/file/member/**
+
             - id: core-service
               uri: http://core-service:80
               predicates:

--- a/member-service/src/main/java/com/green/member/application/admin/AdminBatchService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminBatchService.java
@@ -4,7 +4,7 @@ import com.green.common.auth.MemberContext;
 import com.green.member.application.admin.model.AdminCreateReq;
 import com.green.member.application.admin.model.FailRowRes;
 import com.green.member.application.member.MemberBatchService;
-import com.green.member.enumcode.EnumAdminStatus;
+import com.green.common.enumcode.EnumAdminStatus;
 import lombok.RequiredArgsConstructor;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;

--- a/member-service/src/main/java/com/green/member/application/admin/AdminService.java
+++ b/member-service/src/main/java/com/green/member/application/admin/AdminService.java
@@ -48,7 +48,7 @@ import com.green.member.entity.member.AdminHistory;
 import com.green.member.entity.member.Member;
 import com.green.member.entity.professor.Professor;
 import com.green.member.entity.professor.ProfessorHistory;
-import com.green.member.enumcode.EnumAdminStatus;
+import com.green.common.enumcode.EnumAdminStatus;
 import com.green.member.enumcode.EnumMajorRequestType;
 import com.green.member.enumcode.EnumProfessorPosition;
 import org.springframework.core.io.Resource;
@@ -480,6 +480,7 @@ public class AdminService {
         if (!before.isEmpty()) {
             memberHistoryService.save(memberCode, updaterCode, before);
         }
+
     }
 
     @Transactional
@@ -537,6 +538,7 @@ public class AdminService {
                     .build();
             outboxService.saveToOutbox(MemberTopic.AUTH_MEMBER, memberCode, authEvent);
         }
+
     }
 
     @Transactional

--- a/member-service/src/main/java/com/green/member/application/admin/model/AdminCreateReq.java
+++ b/member-service/src/main/java/com/green/member/application/admin/model/AdminCreateReq.java
@@ -1,7 +1,7 @@
 package com.green.member.application.admin.model;
 
 import com.green.member.application.member.model.MemberCreateReq;
-import com.green.member.enumcode.EnumAdminStatus;
+import com.green.common.enumcode.EnumAdminStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/member-service/src/main/java/com/green/member/application/admin/model/AdminHistoryRes.java
+++ b/member-service/src/main/java/com/green/member/application/admin/model/AdminHistoryRes.java
@@ -1,6 +1,6 @@
 package com.green.member.application.admin.model;
 
-import com.green.member.enumcode.EnumAdminStatus;
+import com.green.common.enumcode.EnumAdminStatus;
 import lombok.Data;
 import lombok.ToString;
 

--- a/member-service/src/main/java/com/green/member/application/admin/model/AdminProfileRes.java
+++ b/member-service/src/main/java/com/green/member/application/admin/model/AdminProfileRes.java
@@ -1,8 +1,6 @@
 package com.green.member.application.admin.model;
 
 import com.green.member.application.member.model.MemberProfileRes;
-import com.green.member.enumcode.EnumAdminStatus;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;

--- a/member-service/src/main/java/com/green/member/application/admin/model/StatusUpdateAdminReq.java
+++ b/member-service/src/main/java/com/green/member/application/admin/model/StatusUpdateAdminReq.java
@@ -1,6 +1,6 @@
 package com.green.member.application.admin.model;
 
-import com.green.member.enumcode.EnumAdminStatus;
+import com.green.common.enumcode.EnumAdminStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/member-service/src/main/java/com/green/member/application/professor/model/StatusUpdateProfessorReq.java
+++ b/member-service/src/main/java/com/green/member/application/professor/model/StatusUpdateProfessorReq.java
@@ -1,9 +1,7 @@
 package com.green.member.application.professor.model;
 
 import com.green.common.enumcode.EnumProfessorStatus;
-import com.green.member.enumcode.EnumAdminStatus;
 import com.green.member.enumcode.EnumProfessorPosition;
-import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 

--- a/member-service/src/main/java/com/green/member/application/status/StatusRequestRepository.java
+++ b/member-service/src/main/java/com/green/member/application/status/StatusRequestRepository.java
@@ -28,6 +28,8 @@ public interface StatusRequestRepository extends JpaRepository<StatusRequest, Lo
                    sr.status           AS status,
                    sr.academic_year    AS academicYear,
                    sr.semester         AS semester,
+                   sr.return_year      AS returnYear,
+                   sr.return_semester  AS returnSemester,
                    sr.created_at       AS createdAt
             FROM status_request sr
             WHERE sr.student_code = :memberCode

--- a/member-service/src/main/java/com/green/member/application/status/model/StudentStatusRequestListRes.java
+++ b/member-service/src/main/java/com/green/member/application/status/model/StudentStatusRequestListRes.java
@@ -8,5 +8,7 @@ public interface StudentStatusRequestListRes {
     String getStatus();
     Integer getAcademicYear();
     Integer getSemester();
+    Integer getReturnYear();
+    Integer getReturnSemester();
     LocalDateTime getCreatedAt();
 }

--- a/member-service/src/main/java/com/green/member/application/student/StudentService.java
+++ b/member-service/src/main/java/com/green/member/application/student/StudentService.java
@@ -351,12 +351,14 @@ public class StudentService {
         statusRequestRepository.findStudentStatusRequests(memberCode).forEach(r ->
                 merged.add(new StudentDashboardRequestRes(
                         r.getRequestId(), "STATUS", r.getType(), null,
+                        r.getReturnYear(), r.getReturnSemester(),
                         r.getStatus(), r.getAcademicYear(), r.getSemester(), r.getCreatedAt()
                 ))
         );
         majorRequestRepository.findStudentMajorRequests(memberCode).forEach(r ->
                 merged.add(new StudentDashboardRequestRes(
                         r.getRequestId(), "MAJOR", r.getType(), r.getTargetMajorName(),
+                        null, null,
                         r.getStatus(), r.getAcademicYear(), r.getSemester(), r.getCreatedAt()
                 ))
         );

--- a/member-service/src/main/java/com/green/member/application/student/model/StudentDashboardRequestRes.java
+++ b/member-service/src/main/java/com/green/member/application/student/model/StudentDashboardRequestRes.java
@@ -11,7 +11,9 @@ public class StudentDashboardRequestRes {
     private Long requestId;
     private String requestCategory; // STATUS | MAJOR
     private String type;
-    private String targetMajorName; // 전공변경 신청에만 값 존재, 학적변경은 null
+    private String targetMajorName; // 전공변경(TRANSFER/MINOR) 신청에만 값 존재
+    private Integer returnYear;     // 휴학(ABSENCE) 신청에만 값 존재
+    private Integer returnSemester; // 휴학(ABSENCE) 신청에만 값 존재
     private String status;
     private Integer academicYear;
     private Integer semester;

--- a/member-service/src/main/java/com/green/member/entity/member/Admin.java
+++ b/member-service/src/main/java/com/green/member/entity/member/Admin.java
@@ -1,7 +1,7 @@
 package com.green.member.entity.member;
 
 import com.green.common.entity.UpdatedAt;
-import com.green.member.enumcode.EnumAdminStatus;
+import com.green.common.enumcode.EnumAdminStatus;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/member-service/src/main/java/com/green/member/entity/member/AdminHistory.java
+++ b/member-service/src/main/java/com/green/member/entity/member/AdminHistory.java
@@ -1,7 +1,7 @@
 package com.green.member.entity.member;
 
 import com.green.common.entity.CreatedAt;
-import com.green.member.enumcode.EnumAdminStatus;
+import com.green.common.enumcode.EnumAdminStatus;
 import com.green.member.enumcode.NullableAdminStatusConverter;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;

--- a/member-service/src/main/java/com/green/member/enumcode/NullableAdminStatusConverter.java
+++ b/member-service/src/main/java/com/green/member/enumcode/NullableAdminStatusConverter.java
@@ -1,6 +1,7 @@
 package com.green.member.enumcode;
 
 import com.green.common.enumcode.AbstractEnumCodeConverter;
+import com.green.common.enumcode.EnumAdminStatus;
 import jakarta.persistence.Converter;
 
 @Converter


### PR DESCRIPTION
## 작업 내용

###  버그 수정

  [fix] 배포 환경 프로필 이미지 404                                                                                                                                                         
  - gateway/application-prod.yaml에 /file/** → member-service 라우팅 누락                                                                                                                                        
  - member-file 라우트 추가

  [fix] 학적변경/전공변경 신청 POST 500 에러
  - core-service GradeQueryRepository.calcWeightedGpaByStudentCode에서 MySQL이 반환하는 BigDecimal을 Double로 직접 캐스팅하다 ClassCastException 발생
  - (Double) → (Number).doubleValue()로 수정
  - 두 신청 엔드포인트 모두 내부적으로 coreServiceClient.getGpa() 호출하므로 동시 해결

  ---
###  기능 개선

  [feat] 대시보드 학생 신청 목록 API 응답 필드 추가
  - 휴학(ABSENCE) 신청: returnYear, returnSemester 추가
  - 전과/부전공(MAJOR) 신청: 기존 targetMajorName 유지
  - 변경 파일: StudentStatusRequestListRes, StatusRequestRepository 쿼리, StudentDashboardRequestRes, StudentService                                                                                                                

  ---
###  리팩토링

  [refactor] EnumAdminStatus common 모듈로 이동
  - member-service/enumcode → common/enumcode로 이동
  - core-service에서 사용 가능하도록 위치 변경
  - 관련 import 11개 파일 수정

  [fix] EnumAutoConfiguration 공통 enum 스캔 누락
  - EnumAdminStatus를 common으로 옮긴 후 GET /api/code?code_type=adminStatus 응답 불가 문제 발생
  - EnumAutoConfiguration에 com.green.common.enumcode 패키지 고정 스캔 추가
  - 이후 common에 추가되는 모든 enum 자동 등록