### PR TITLE
fix(member) 전공 변경시 core-service에서 캐시 이벤트 발행 안되는 문제 해결

### DIFF
--- a/core-service/src/main/java/com/green/core/config/KafkaConsumerConfig.java
+++ b/core-service/src/main/java/com/green/core/config/KafkaConsumerConfig.java
@@ -1,0 +1,21 @@
+package com.green.core.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.support.converter.StringJacksonJsonMessageConverter;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<?, ?> kafkaListenerContainerFactory(
+            ConsumerFactory<Object, Object> consumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<Object, Object> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        factory.setRecordMessageConverter(new StringJacksonJsonMessageConverter());
+        return factory;
+    }
+}

--- a/core-service/src/main/java/com/green/core/kafka/StudentConsumer.java
+++ b/core-service/src/main/java/com/green/core/kafka/StudentConsumer.java
@@ -63,6 +63,10 @@ public class StudentConsumer {
                             event.getAcademicYear(),
                             event.getSemester()
                     );
+                } else if (UpdateType.MAJOR_TRANSFER == updateType) {
+                    studentCacheRepository.updateMajorId(event.getMemberCode(), event.getMajorId());
+                } else if (UpdateType.MAJOR_MINOR == updateType) {
+                    studentCacheRepository.updateMinorId(event.getMemberCode(), event.getMinorId());
                 }
             }
 

--- a/core-service/src/main/java/com/green/core/repository/StudentCacheRepository.java
+++ b/core-service/src/main/java/com/green/core/repository/StudentCacheRepository.java
@@ -50,6 +50,16 @@ public interface StudentCacheRepository extends JpaRepository<StudentCache, Long
                         @Param("academicYear") Integer academicYear,
                         @Param("semester") Integer semester);
 
+    // 전과 승인 시
+    @Modifying
+    @Query("UPDATE StudentCache s SET s.majorId = :majorId WHERE s.memberCode = :memberCode")
+    void updateMajorId(@Param("memberCode") Long memberCode, @Param("majorId") Long majorId);
+
+    // 부전공 승인 시
+    @Modifying
+    @Query("UPDATE StudentCache s SET s.minorId = :minorId WHERE s.memberCode = :memberCode")
+    void updateMinorId(@Param("memberCode") Long memberCode, @Param("minorId") Long minorId);
+
     List<StudentCache> findAllByStatus(EnumStudentStatus status);
     List<StudentCache> findByNameContaining(String name);
 }

--- a/core-service/src/main/resources/application-prod.yaml
+++ b/core-service/src/main/resources/application-prod.yaml
@@ -43,8 +43,6 @@ spring:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
     consumer:
       group-id: core-service-group
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: "com.green.common.model,com.green.common.kafka"
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 outbox:
   enabled: true

--- a/core-service/src/main/resources/application.yaml
+++ b/core-service/src/main/resources/application.yaml
@@ -70,8 +70,9 @@ spring:
     # [수신] Student, Professor, Calendar 캐시를 업데이트
     consumer:
       group-id: core-service-group
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer  # 추가
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer  # 변경
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       properties:
         spring.json.trusted.packages: "*"
 outbox:

--- a/member-service/src/main/resources/application-prod.yaml
+++ b/member-service/src/main/resources/application-prod.yaml
@@ -39,7 +39,7 @@ spring:
     bootstrap-servers: kafka.infra.svc.cluster.local:9092
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
     consumer:
       group-id: member-service-group
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer

--- a/member-service/src/main/resources/application.yaml
+++ b/member-service/src/main/resources/application.yaml
@@ -44,9 +44,7 @@ spring:
     # [발행] student, professor 이벤트를 Outbox에 담아 보냄
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-      properties:
-        spring.json.add.type.headers: true   # 추가
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
     # [수신] Major 캐시 정보를 받기 위한 설정
     consumer:
       group-id: member-service-group


### PR DESCRIPTION
## 작업 내용
  문제
  
  전공변경 신청 승인 시 member-service의 student_major는 정상 업데이트되나, core-service의 studentCache가 동기화되지 않는 버그

  ---
  원인 분석 (3가지)
  
  1. StudentConsumer 핸들러 누락 (핵심 버그)
  MAJOR_TRANSFER, MAJOR_MINOR 이벤트 타입에 대한 처리 분기가 없어 이벤트 수신 시 아무 처리도 하지 않고 통과

  2. Kafka 메시지 컨버터 미연결
  common/KafkaConfiguration의 StringJacksonJsonMessageConverter 빈이 Spring context에 등록되지만, Spring Boot 4.x에서 RecordMessageConverter는 ConcurrentKafkaListenerContainerFactory에 자동 주입되지 않음. @KafkaListener 메서드가
  String → 도메인 객체 변환에 실패하여 핸들러 자체가 호출되지 않음

  3. Kafka 메시지 이중 인코딩
  OutboxRelay가 KafkaTemplate<String, String>으로 String payload를 전송할 때 producer에 JsonSerializer를 사용하면 Jackson이 String을 JSON string으로 한 번 더 감싸 역직렬화 불가 상태로 전송됨

  ---
  수정 내용

  ┌──────────────────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │                       파일                       │                                                                   내용                                                                   │
  ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ core-service/.../StudentConsumer.java            │ MAJOR_TRANSFER → updateMajorId(), MAJOR_MINOR → updateMinorId() 핸들러 추가                                                              │
  ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ core-service/.../StudentCacheRepository.java     │ updateMajorId(), updateMinorId() JPQL 쿼리 메서드 추가                                                                                   │
  ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ core-service/.../config/KafkaConsumerConfig.java │ 신규 — kafkaListenerContainerFactory 빈 명시적 정의, StringJacksonJsonMessageConverter 연결 (core-service에만 적용, 타 서비스 영향 없음) │
  ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ member-service/application.yaml                  │ producer value-serializer: JsonSerializer → StringSerializer (이중 인코딩 제거)                                                          │
  ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ member-service/application-prod.yaml             │ 동일                                                                                                                                     │
  ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ core-service/application-prod.yaml               │ consumer value-deserializer: JsonDeserializer → StringDeserializer (prod/dev 일관성)                                                     │
  └──────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

  ---
  영향 범위

  - KafkaConsumerConfig는 core-service 전용으로 생성되어 member-service, academic-service 등 타 서비스의 Kafka 동작에 영향 없음
  - member-service producer의 StringSerializer 전환으로 core-service의 StudentConsumer, ProfessorConsumer, GraduationCheckConsumer가 함께 정상화됨