### PR TITLE
fix(member): MajorRequest·StatusRequest updaterCode 미노출 및 학생 처리일시 추가

### DIFF
--- a/member-service/src/main/java/com/green/member/application/major/MajorRequestRepository.java
+++ b/member-service/src/main/java/com/green/member/application/major/MajorRequestRepository.java
@@ -33,9 +33,9 @@ public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long
             SELECT mr.request_id       AS requestId,
                    ms.member_code       AS memberCode,
                    ms.name              AS studentName,
-                   ma.name              AS updaterName,
-                   mr.updater_code     AS updaterCode,
-                   mc.name             AS targetMajorName,
+                   ma.name                      AS updaterName,
+                   CAST(mr.updater_code AS CHAR) AS updaterCode,
+                   mc.name                      AS targetMajorName,
                    mc_current.name     AS currentMajorName,
                    mc_minor.name       AS currentMinorName,
                    mr.type             AS type,
@@ -86,9 +86,9 @@ public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long
                    mr.semester            AS semester,
                    mr.original_file_name  AS originalFileName,
                    mr.reject_reason       AS rejectReason,
-                   um.name                AS updaterName,
-                   mr.updater_code        AS updaterCode,
-                   s.status               AS academicStatus,
+                   um.name                       AS updaterName,
+                   CAST(mr.updater_code AS CHAR)  AS updaterCode,
+                   s.status                       AS academicStatus,
                    mr.created_at          AS createdAt,
                    mr.updated_at          AS updatedAt
             FROM major_request mr
@@ -135,7 +135,8 @@ public interface MajorRequestRepository extends JpaRepository<MajorRequest, Long
                    mr.semester            AS semester,
                    mc_current.name        AS currentMajorName,
                    mc_minor.name          AS currentMinorName,
-                   mr.created_at          AS createdAt
+                   mr.created_at          AS createdAt,
+                   mr.updated_at          AS updatedAt
             FROM major_request mr
             JOIN major_cache mc_target  ON mc_target.major_id  = mr.target_major_id
             JOIN major_cache mc_current ON mc_current.major_id = mr.current_major_id

--- a/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestDetailDto.java
+++ b/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestDetailDto.java
@@ -21,7 +21,7 @@ public interface AdminMajorRequestDetailDto {
     String getOriginalFileName();
     String getRejectReason();
     String getUpdaterName();
-    Long getUpdaterCode();
+    String getUpdaterCode();
     Integer getAcademicYear();
     Integer getSemester();
     LocalDateTime getCreatedAt();

--- a/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestDetailRes.java
+++ b/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestDetailRes.java
@@ -24,7 +24,7 @@ public class AdminMajorRequestDetailRes {
     String originalFileName;
     String rejectReason;
     String updaterName;
-    Long updaterCode;
+    String updaterCode;
     Integer academicYear;
     Integer semester;
     String currentMajorName;

--- a/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestListRes.java
+++ b/member-service/src/main/java/com/green/member/application/major/model/AdminMajorRequestListRes.java
@@ -10,7 +10,7 @@ public interface AdminMajorRequestListRes {
     String getCurrentMajorName();
     String getCurrentMinorName();
     String getUpdaterName();
-    Long getUpdaterCode();
+    String getUpdaterCode();
     Integer getAcademicYear();
     Integer getSemester();
     String getType();

--- a/member-service/src/main/java/com/green/member/application/major/model/StudentMajorRequestDetailRes.java
+++ b/member-service/src/main/java/com/green/member/application/major/model/StudentMajorRequestDetailRes.java
@@ -18,4 +18,5 @@ public interface StudentMajorRequestDetailRes {
     String getCurrentMajorName();
     String getCurrentMinorName();
     LocalDateTime getCreatedAt();
+    LocalDateTime getUpdatedAt();
 }

--- a/member-service/src/main/java/com/green/member/application/status/StatusRequestRepository.java
+++ b/member-service/src/main/java/com/green/member/application/status/StatusRequestRepository.java
@@ -59,7 +59,8 @@ public interface StatusRequestRepository extends JpaRepository<StatusRequest, Lo
                    sr.start_date          AS startDate,
                    sr.return_year         AS returnYear,
                    sr.return_semester     AS returnSemester,
-                   sr.created_at          AS createdAt
+                   sr.created_at          AS createdAt,
+                   sr.updated_at          AS updatedAt
             FROM status_request sr
             WHERE sr.request_id  = :requestId
               AND sr.student_code = :memberCode
@@ -73,9 +74,9 @@ public interface StatusRequestRepository extends JpaRepository<StatusRequest, Lo
             SELECT sr.request_id       AS requestId,
                    ms.member_code       AS memberCode,
                    ms.name              AS studentName,
-                   ma.name              AS updaterName,
-                   sr.updater_code     AS updaterCode,
-                   sr.type             AS type,
+                   ma.name                      AS updaterName,
+                   CAST(sr.updater_code AS CHAR) AS updaterCode,
+                   sr.type                      AS type,
                    sr.status           AS status,
                    sr.academic_year    AS academicYear,
                    sr.semester         AS semester,
@@ -117,9 +118,9 @@ public interface StatusRequestRepository extends JpaRepository<StatusRequest, Lo
                    sr.return_semester     AS returnSemester,
                    sr.original_file_name  AS originalFileName,
                    sr.reject_reason       AS rejectReason,
-                   um.name                AS updaterName,
-                   sr.updater_code        AS updaterCode,
-                   sr.start_date          AS startDate,
+                   um.name                       AS updaterName,
+                   CAST(sr.updater_code AS CHAR)  AS updaterCode,
+                   sr.start_date                  AS startDate,
                    sr.created_at          AS createdAt,
                    sr.updated_at          AS updatedAt,
                    sr.total_credits           AS totalCredits,

--- a/member-service/src/main/java/com/green/member/application/status/model/AdminStatusRequestDetailDto.java
+++ b/member-service/src/main/java/com/green/member/application/status/model/AdminStatusRequestDetailDto.java
@@ -16,7 +16,7 @@ public interface AdminStatusRequestDetailDto {
     String getOriginalFileName();
     String getRejectReason();
     String getUpdaterName();
-    Long getUpdaterCode();
+    String getUpdaterCode();
     Integer getAcademicYear();
     Integer getSemester();
     Integer getReturnYear();

--- a/member-service/src/main/java/com/green/member/application/status/model/AdminStatusRequestDetailRes.java
+++ b/member-service/src/main/java/com/green/member/application/status/model/AdminStatusRequestDetailRes.java
@@ -24,7 +24,7 @@ public class AdminStatusRequestDetailRes {
     String originalFileName;
     String rejectReason;
     String updaterName;
-    Long updaterCode;
+    String updaterCode;
     Integer academicYear;
     Integer semester;
     Integer returnYear;

--- a/member-service/src/main/java/com/green/member/application/status/model/AdminStatusRequestListRes.java
+++ b/member-service/src/main/java/com/green/member/application/status/model/AdminStatusRequestListRes.java
@@ -7,7 +7,7 @@ public interface AdminStatusRequestListRes {
     Long getMemberCode();
     String getStudentName();
     String getUpdaterName();
-    Long getUpdaterCode();
+    String getUpdaterCode();
     Integer getAcademicYear();
     Integer getSemester();
     String getType();

--- a/member-service/src/main/java/com/green/member/application/status/model/StudentStatusRequestDetailRes.java
+++ b/member-service/src/main/java/com/green/member/application/status/model/StudentStatusRequestDetailRes.java
@@ -17,4 +17,5 @@ public interface StudentStatusRequestDetailRes {
     Integer getReturnYear();
     Integer getReturnSemester();
     LocalDateTime getCreatedAt();
+    LocalDateTime getUpdatedAt();
 }


### PR DESCRIPTION
## 작업내용
  - updaterCode JSON 미노출 버그 수정
    - 원인: Spring Data JPA native query + interface projection 조합에서 nullable BIGINT 컬럼을 Long getter로 매핑 시 변환 실패 → null 반환 → 전역 non_null 설정으로 JSON에서 제거됨
    - 수정: 목록·상세 쿼리에 CAST(updater_code AS CHAR)를 적용하고, 관련 interface getter 및 Res 클래스의 타입을 Long → String으로 변경
  - 학생 신청서 상세에 처리일시(updatedAt) 추가
    - StudentMajorRequestDetailRes, StudentStatusRequestDetailRes 인터페이스에 getUpdatedAt() 추가
    - 각 Repository 학생 상세 조회 쿼리에 updated_at AS updatedAt 컬럼 추가

  ---
  Changed Files

  updaterCode 버그 수정
  - AdminMajorRequestListRes — Long → String getter 변경
  - AdminStatusRequestListRes — Long → String getter 변경
  - AdminMajorRequestDetailDto — Long → String getter 변경
  - AdminStatusRequestDetailDto — Long → String getter 변경
  - AdminMajorRequestDetailRes — Long → String 필드 변경
  - AdminStatusRequestDetailRes — Long → String 필드 변경
  - MajorRequestRepository — 목록·상세 쿼리에 CAST(mr.updater_code AS CHAR) 적용
  - StatusRequestRepository — 목록·상세 쿼리에 CAST(sr.updater_code AS CHAR) 적용

  학생 처리일시 추가
  - StudentMajorRequestDetailRes — getUpdatedAt() 추가
  - StudentStatusRequestDetailRes — getUpdatedAt() 추가
  - MajorRequestRepository — 학생 상세 쿼리에 mr.updated_at AS updatedAt 추가
  - StatusRequestRepository — 학생 상세 쿼리에 sr.updated_at AS updatedAt 추가
